### PR TITLE
Use OpenMapTiles license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,60 @@
+Copyright (c) 2022, MapTiler.com & OpenMapTiles contributors.  
+All rights reserved.
+
+The vector tile schema has been developed by Klokan Technologies GmbH and
+was initially modelled after the cartography of the CARTO's Positron basemap
+with permission from CartoDB Inc.
+The vector tile schema has been refined and improved in cooperation with
+the Wikimedia Foundation and is heavily influenced by years of
+Paul Norman's experience of creating maps from OpenStreetMap data.
+
+# Code license: BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Design license: CC-BY 4.0
+
+The cartography and visual design features of the map tile schema (also known as
+the "look and feel" of the map) are licensed under the Creative Commons
+Attribution 4.0 license.
+To view a copy of the license, visit http://creativecommons.org/licenses/by/4.0/.
+
+Products or services using maps derived from OpenMapTiles schema need to visibly
+credit "OpenMapTiles.org" or reference "OpenMapTiles" with a link to
+http://openmaptiles.org/.
+
+For a browsable electronic map based on OpenMapTiles and OpenStreetMap data, the
+credit should appear in the corner of the map. For example:
+
+[© OpenMapTiles](http://openmaptiles.org/) [© OpenStreetMap contributors](http://www.openstreetmap.org/copyright)
+
+For printed and static maps a similar attribution should be made in a textual
+description near the image, in the same fashion as if you cite a photograph.
+
+Exceptions to OpenMapTiles attribution requirement can be in a written form granted
+by MapTiler (info@maptiler.com).  
+The project contributors grant MapTiler AG the license to give such
+exceptions on a commercial basis.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ If you want to regenerate from a different repository than the default openmapti
 ./scripts/regenerate-openmaptiles.sh v3.13.1 https://raw.githubusercontent.com/openmaptiles/openmaptiles/
 ```
 
-## License and Attribution
+## License
 
-OpenMapTiles code is licensed under the BSD 3-Clause License, which appears at the top of any file ported from
-OpenMapTiles.
+All code in this repository is under the [BSD license](./LICENSE.md) and the cartography decisions encoded in the schema and SQL are licensed under [CC-BY](./LICENSE.md).
 
-The OpenMapTiles schema (or "look and feel") is licensed under [CC-BY 4.0](http://creativecommons.org/licenses/by/4.0/),
-so any map derived from that schema
-must [visibly credit OpenMapTiles](https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md#design-license-cc-by-40)
-. It also uses OpenStreetMap data, so you
-must [visibly credit OpenStreetMap contributors](https://www.openstreetmap.org/copyright).
+Products or services using maps derived from OpenMapTiles schema need to visibly credit "OpenMapTiles.org" or reference "OpenMapTiles" with a link to https://openmaptiles.org/. Exceptions to attribution requirement can be granted on request.
+
+For a browsable electronic map based on OpenMapTiles and OpenStreetMap data, the
+credit should appear in the corner of the map. For example:
+
+[© OpenMapTiles](https://openmaptiles.org/) [© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)
+
+For printed and static maps a similar attribution should be made in a textual
+description near the image, in the same fashion as if you cite a photograph.


### PR DESCRIPTION
This PR updates the README.md and adds LICENSE.md file to match the license from the [OpenMapTiles](https://github.com/openmaptiles/openmaptiles) repo.