### PR TITLE
Fix jib tags

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -23,7 +23,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: 'Build and push to dockerhub'
-        run: ./mvnw -B -ntp -Pjib-multi-arch -Dimage.tags="latest" package jib:build --file pom.xml
+        run: ./mvnw -B -ntp -Pjib-multi-arch -Djib.to.tags="latest" package jib:build --file pom.xml
       - run: sha256sum target/*with-deps.jar
       - run: md5sum target/*with-deps.jar
       - name: 'Upload artifact'


### PR DESCRIPTION
Fix jib tag argument so that it properly sets `latest` tag on each image that it pushes to dockerhub.