### PR TITLE
Get parent version from revision variable

### DIFF
--- a/submodule.pom.xml
+++ b/submodule.pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.onthegomap.planetiler</groupId>
     <artifactId>planetiler-parent</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
Follow the approach described [here](https://maven.apache.org/maven-ci-friendly.html) to make it easier to bump planetiler revisions without making changes in planetiler-openmaptiles repo.  The submodule CI job will fail until I land the corresponding change to planetiler repo.