### PR TITLE
Coalesce speedup

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Building.java
+++ b/src/main/java/org/openmaptiles/layers/Building.java
@@ -38,7 +38,7 @@ package org.openmaptiles.layers;
 import static com.onthegomap.planetiler.util.MemoryEstimator.CLASS_HEADER_BYTES;
 import static com.onthegomap.planetiler.util.Parse.parseDoubleOrNull;
 import static java.util.Map.entry;
-import static org.openmaptiles.util.Utils.coalesceF;
+import static org.openmaptiles.util.Utils.coalesceLazy;
 
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
@@ -141,19 +141,19 @@ public class Building implements
     }
 
     Function<String, Double> f = Parse::parseDoubleOrNull;
-    Double height = coalesceF(
+    Double height = coalesceLazy(
       parseDoubleOrNull(element.height()),
       f, element.buildingheight()
     );
-    Double minHeight = coalesceF(
+    Double minHeight = coalesceLazy(
       parseDoubleOrNull(element.minHeight()),
       f, element.buildingminHeight()
     );
-    Double levels = coalesceF(
+    Double levels = coalesceLazy(
       parseDoubleOrNull(element.levels()),
       f, element.buildinglevels()
     );
-    Double minLevels = coalesceF(
+    Double minLevels = coalesceLazy(
       parseDoubleOrNull(element.minLevel()),
       f, element.buildingminLevel()
     );

--- a/src/main/java/org/openmaptiles/layers/Building.java
+++ b/src/main/java/org/openmaptiles/layers/Building.java
@@ -38,7 +38,7 @@ package org.openmaptiles.layers;
 import static com.onthegomap.planetiler.util.MemoryEstimator.CLASS_HEADER_BYTES;
 import static com.onthegomap.planetiler.util.Parse.parseDoubleOrNull;
 import static java.util.Map.entry;
-import static org.openmaptiles.util.Utils.coalesce;
+import static org.openmaptiles.util.Utils.coalesceF;
 
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
@@ -49,10 +49,12 @@ import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.MemoryEstimator;
+import com.onthegomap.planetiler.util.Parse;
 import com.onthegomap.planetiler.util.Translations;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
@@ -138,21 +140,22 @@ public class Building implements
       color = color.toLowerCase(Locale.ROOT);
     }
 
-    Double height = coalesce(
+    Function<String, Double> f = Parse::parseDoubleOrNull;
+    Double height = coalesceF(
       parseDoubleOrNull(element.height()),
-      parseDoubleOrNull(element.buildingheight())
+      f, element.buildingheight()
     );
-    Double minHeight = coalesce(
+    Double minHeight = coalesceF(
       parseDoubleOrNull(element.minHeight()),
-      parseDoubleOrNull(element.buildingminHeight())
+      f, element.buildingminHeight()
     );
-    Double levels = coalesce(
+    Double levels = coalesceF(
       parseDoubleOrNull(element.levels()),
-      parseDoubleOrNull(element.buildinglevels())
+      f, element.buildinglevels()
     );
-    Double minLevels = coalesce(
+    Double minLevels = coalesceF(
       parseDoubleOrNull(element.minLevel()),
-      parseDoubleOrNull(element.buildingminLevel())
+      f, element.buildingminLevel()
     );
 
     int renderHeight = (int) Math.ceil(height != null ? height : levels != null ? (levels * 3.66) : 5);

--- a/src/main/java/org/openmaptiles/layers/Building.java
+++ b/src/main/java/org/openmaptiles/layers/Building.java
@@ -49,12 +49,10 @@ import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.MemoryEstimator;
-import com.onthegomap.planetiler.util.Parse;
 import com.onthegomap.planetiler.util.Translations;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
@@ -140,22 +138,21 @@ public class Building implements
       color = color.toLowerCase(Locale.ROOT);
     }
 
-    Function<String, Double> f = Parse::parseDoubleOrNull;
     Double height = coalesceLazy(
       parseDoubleOrNull(element.height()),
-      f, element.buildingheight()
+      () -> parseDoubleOrNull(element.buildingheight())
     );
     Double minHeight = coalesceLazy(
       parseDoubleOrNull(element.minHeight()),
-      f, element.buildingminHeight()
+      () -> parseDoubleOrNull(element.buildingminHeight())
     );
     Double levels = coalesceLazy(
       parseDoubleOrNull(element.levels()),
-      f, element.buildinglevels()
+      () -> parseDoubleOrNull(element.buildinglevels())
     );
     Double minLevels = coalesceLazy(
       parseDoubleOrNull(element.minLevel()),
-      f, element.buildingminLevel()
+      () -> parseDoubleOrNull(element.buildingminLevel())
     );
 
     int renderHeight = (int) Math.ceil(height != null ? height : levels != null ? (levels * 3.66) : 5);

--- a/src/main/java/org/openmaptiles/layers/Landuse.java
+++ b/src/main/java/org/openmaptiles/layers/Landuse.java
@@ -35,7 +35,7 @@ See https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md for deta
 */
 package org.openmaptiles.layers;
 
-import static org.openmaptiles.util.Utils.coalesce;
+import static org.openmaptiles.util.Utils.coalesceF;
 import static org.openmaptiles.util.Utils.nullIfEmpty;
 
 import com.onthegomap.planetiler.FeatureCollector;
@@ -47,9 +47,11 @@ import com.onthegomap.planetiler.util.Translations;
 import com.onthegomap.planetiler.util.ZoomFunction;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
+import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating map elements for man-made land use polygons like cemeteries, zoos, and hospitals in
@@ -91,13 +93,14 @@ public class Landuse implements
 
   @Override
   public void process(Tables.OsmLandusePolygon element, FeatureCollector features) {
-    String clazz = coalesce(
+    Function<String, String> f = Utils::nullIfEmpty;
+    String clazz = coalesceF(
       nullIfEmpty(element.landuse()),
-      nullIfEmpty(element.amenity()),
-      nullIfEmpty(element.leisure()),
-      nullIfEmpty(element.tourism()),
-      nullIfEmpty(element.place()),
-      nullIfEmpty(element.waterway())
+      f, element.amenity(),
+      f, element.leisure(),
+      f, element.tourism(),
+      f, element.place(),
+      f, element.waterway()
     );
     if (clazz != null) {
       if ("grave_yard".equals(clazz)) {

--- a/src/main/java/org/openmaptiles/layers/Landuse.java
+++ b/src/main/java/org/openmaptiles/layers/Landuse.java
@@ -35,7 +35,7 @@ See https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md for deta
 */
 package org.openmaptiles.layers;
 
-import static org.openmaptiles.util.Utils.coalesceF;
+import static org.openmaptiles.util.Utils.coalesceLazy;
 import static org.openmaptiles.util.Utils.nullIfEmpty;
 
 import com.onthegomap.planetiler.FeatureCollector;
@@ -94,7 +94,7 @@ public class Landuse implements
   @Override
   public void process(Tables.OsmLandusePolygon element, FeatureCollector features) {
     Function<String, String> f = Utils::nullIfEmpty;
-    String clazz = coalesceF(
+    String clazz = coalesceLazy(
       nullIfEmpty(element.landuse()),
       f, element.amenity(),
       f, element.leisure(),

--- a/src/main/java/org/openmaptiles/layers/Landuse.java
+++ b/src/main/java/org/openmaptiles/layers/Landuse.java
@@ -47,11 +47,9 @@ import com.onthegomap.planetiler.util.Translations;
 import com.onthegomap.planetiler.util.ZoomFunction;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
-import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating map elements for man-made land use polygons like cemeteries, zoos, and hospitals in
@@ -93,14 +91,13 @@ public class Landuse implements
 
   @Override
   public void process(Tables.OsmLandusePolygon element, FeatureCollector features) {
-    Function<String, String> f = Utils::nullIfEmpty;
     String clazz = coalesceLazy(
       nullIfEmpty(element.landuse()),
-      f, element.amenity(),
-      f, element.leisure(),
-      f, element.tourism(),
-      f, element.place(),
-      f, element.waterway()
+      () -> nullIfEmpty(element.amenity()),
+      () -> nullIfEmpty(element.leisure()),
+      () -> nullIfEmpty(element.tourism()),
+      () -> nullIfEmpty(element.place()),
+      () -> nullIfEmpty(element.waterway())
     );
     if (clazz != null) {
       if ("grave_yard".equals(clazz)) {

--- a/src/main/java/org/openmaptiles/layers/Park.java
+++ b/src/main/java/org/openmaptiles/layers/Park.java
@@ -53,12 +53,10 @@ import com.onthegomap.planetiler.util.SortKey;
 import com.onthegomap.planetiler.util.Translations;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
-import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating map elements for designated parks polygons and their label points in the {@code
@@ -97,11 +95,10 @@ public class Park implements
     if (protectionTitle != null) {
       protectionTitle = protectionTitle.replace(' ', '_').toLowerCase(Locale.ROOT);
     }
-    Function<String, String> f = Utils::nullIfEmpty;
     String clazz = coalesceLazy(
       nullIfEmpty(protectionTitle),
-      f, element.boundary(),
-      f, element.leisure()
+      () -> nullIfEmpty(element.boundary()),
+      () -> nullIfEmpty(element.leisure())
     );
 
     // park shape

--- a/src/main/java/org/openmaptiles/layers/Park.java
+++ b/src/main/java/org/openmaptiles/layers/Park.java
@@ -36,7 +36,7 @@ See https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md for deta
 package org.openmaptiles.layers;
 
 import static com.onthegomap.planetiler.collection.FeatureGroup.SORT_KEY_BITS;
-import static org.openmaptiles.util.Utils.coalesce;
+import static org.openmaptiles.util.Utils.coalesceF;
 import static org.openmaptiles.util.Utils.nullIfEmpty;
 
 import com.carrotsearch.hppc.LongIntMap;
@@ -53,10 +53,12 @@ import com.onthegomap.planetiler.util.SortKey;
 import com.onthegomap.planetiler.util.Translations;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
+import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating map elements for designated parks polygons and their label points in the {@code
@@ -95,10 +97,11 @@ public class Park implements
     if (protectionTitle != null) {
       protectionTitle = protectionTitle.replace(' ', '_').toLowerCase(Locale.ROOT);
     }
-    String clazz = coalesce(
+    Function<String, String> f = Utils::nullIfEmpty;
+    String clazz = coalesceF(
       nullIfEmpty(protectionTitle),
-      nullIfEmpty(element.boundary()),
-      nullIfEmpty(element.leisure())
+      f, element.boundary(),
+      f, element.leisure()
     );
 
     // park shape

--- a/src/main/java/org/openmaptiles/layers/Park.java
+++ b/src/main/java/org/openmaptiles/layers/Park.java
@@ -36,7 +36,7 @@ See https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md for deta
 package org.openmaptiles.layers;
 
 import static com.onthegomap.planetiler.collection.FeatureGroup.SORT_KEY_BITS;
-import static org.openmaptiles.util.Utils.coalesceF;
+import static org.openmaptiles.util.Utils.coalesceLazy;
 import static org.openmaptiles.util.Utils.nullIfEmpty;
 
 import com.carrotsearch.hppc.LongIntMap;
@@ -98,7 +98,7 @@ public class Park implements
       protectionTitle = protectionTitle.replace(' ', '_').toLowerCase(Locale.ROOT);
     }
     Function<String, String> f = Utils::nullIfEmpty;
-    String clazz = coalesceF(
+    String clazz = coalesceLazy(
       nullIfEmpty(protectionTitle),
       f, element.boundary(),
       f, element.leisure()

--- a/src/main/java/org/openmaptiles/layers/Place.java
+++ b/src/main/java/org/openmaptiles/layers/Place.java
@@ -37,7 +37,7 @@ package org.openmaptiles.layers;
 
 import static com.onthegomap.planetiler.collection.FeatureGroup.SORT_KEY_BITS;
 import static org.openmaptiles.util.Utils.coalesce;
-import static org.openmaptiles.util.Utils.coalesceF;
+import static org.openmaptiles.util.Utils.coalesceLazy;
 import static org.openmaptiles.util.Utils.nullIfEmpty;
 import static org.openmaptiles.util.Utils.nullOrEmpty;
 
@@ -217,7 +217,7 @@ public class Place implements
       return;
     }
     Function<String, String> f = Utils::nullIfEmpty;
-    String isoA2 = coalesceF(
+    String isoA2 = coalesceLazy(
       nullIfEmpty(element.countryCodeIso31661Alpha2()),
       f, element.iso31661Alpha2(),
       f, element.iso31661()

--- a/src/main/java/org/openmaptiles/layers/Place.java
+++ b/src/main/java/org/openmaptiles/layers/Place.java
@@ -63,7 +63,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
@@ -73,7 +72,6 @@ import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
-import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating label points for populated places like continents, countries, cities, and towns in
@@ -216,11 +214,10 @@ public class Place implements
     if (nullOrEmpty(element.name())) {
       return;
     }
-    Function<String, String> f = Utils::nullIfEmpty;
     String isoA2 = coalesceLazy(
       nullIfEmpty(element.countryCodeIso31661Alpha2()),
-      f, element.iso31661Alpha2(),
-      f, element.iso31661()
+      () -> nullIfEmpty(element.iso31661Alpha2()),
+      () -> nullIfEmpty(element.iso31661())
     );
     if (isoA2 == null) {
       return;

--- a/src/main/java/org/openmaptiles/layers/Place.java
+++ b/src/main/java/org/openmaptiles/layers/Place.java
@@ -37,6 +37,7 @@ package org.openmaptiles.layers;
 
 import static com.onthegomap.planetiler.collection.FeatureGroup.SORT_KEY_BITS;
 import static org.openmaptiles.util.Utils.coalesce;
+import static org.openmaptiles.util.Utils.coalesceF;
 import static org.openmaptiles.util.Utils.nullIfEmpty;
 import static org.openmaptiles.util.Utils.nullOrEmpty;
 
@@ -62,6 +63,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
@@ -71,6 +73,7 @@ import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
+import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating label points for populated places like continents, countries, cities, and towns in
@@ -213,10 +216,11 @@ public class Place implements
     if (nullOrEmpty(element.name())) {
       return;
     }
-    String isoA2 = coalesce(
+    Function<String, String> f = Utils::nullIfEmpty;
+    String isoA2 = coalesceF(
       nullIfEmpty(element.countryCodeIso31661Alpha2()),
-      nullIfEmpty(element.iso31661Alpha2()),
-      nullIfEmpty(element.iso31661())
+      f, element.iso31661Alpha2(),
+      f, element.iso31661()
     );
     if (isoA2 == null) {
       return;

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -36,10 +36,7 @@ See https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md for deta
 package org.openmaptiles.layers;
 
 import static java.util.Map.entry;
-import static org.openmaptiles.util.Utils.coalesce;
-import static org.openmaptiles.util.Utils.nullIfEmpty;
-import static org.openmaptiles.util.Utils.nullIfLong;
-import static org.openmaptiles.util.Utils.nullOrEmpty;
+import static org.openmaptiles.util.Utils.*;
 
 import com.carrotsearch.hppc.LongIntMap;
 import com.onthegomap.planetiler.FeatureCollector;
@@ -56,6 +53,7 @@ import java.util.Map;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
+import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating map elements for things like shops, parks, and schools in the {@code poi} layer from
@@ -150,7 +148,9 @@ public class Poi implements
     String name = element.name();
     var tags = element.source().tags();
     if ("atm".equals(rawSubclass) && nullOrEmpty(name)) {
-      name = coalesce(nullIfEmpty(element.operator()), nullIfEmpty(element.network()));
+      name = coalesceF(
+        nullIfEmpty(element.operator()),
+        Utils::nullIfEmpty, element.network());
       if (name != null) {
         tags.put("name", name);
       }

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -36,7 +36,11 @@ See https://github.com/openmaptiles/openmaptiles/blob/master/LICENSE.md for deta
 package org.openmaptiles.layers;
 
 import static java.util.Map.entry;
-import static org.openmaptiles.util.Utils.*;
+import static org.openmaptiles.util.Utils.coalesce;
+import static org.openmaptiles.util.Utils.coalesceLazy;
+import static org.openmaptiles.util.Utils.nullIfEmpty;
+import static org.openmaptiles.util.Utils.nullIfLong;
+import static org.openmaptiles.util.Utils.nullOrEmpty;
 
 import com.carrotsearch.hppc.LongIntMap;
 import com.onthegomap.planetiler.FeatureCollector;
@@ -53,7 +57,6 @@ import java.util.Map;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
-import org.openmaptiles.util.Utils;
 
 /**
  * Defines the logic for generating map elements for things like shops, parks, and schools in the {@code poi} layer from
@@ -150,7 +153,8 @@ public class Poi implements
     if ("atm".equals(rawSubclass) && nullOrEmpty(name)) {
       name = coalesceLazy(
         nullIfEmpty(element.operator()),
-        Utils::nullIfEmpty, element.network());
+        () -> nullIfEmpty(element.network())
+      );
       if (name != null) {
         tags.put("name", name);
       }

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -148,7 +148,7 @@ public class Poi implements
     String name = element.name();
     var tags = element.source().tags();
     if ("atm".equals(rawSubclass) && nullOrEmpty(name)) {
-      name = coalesceF(
+      name = coalesceLazy(
         nullIfEmpty(element.operator()),
         Utils::nullIfEmpty, element.network());
       if (name != null) {

--- a/src/main/java/org/openmaptiles/util/Utils.java
+++ b/src/main/java/org/openmaptiles/util/Utils.java
@@ -2,7 +2,7 @@ package org.openmaptiles.util;
 
 import com.onthegomap.planetiler.util.Parse;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Common utilities for working with data and the OpenMapTiles schema in {@code layers} implementations.
@@ -13,23 +13,23 @@ public class Utils {
     return a != null ? a : b;
   }
 
-  public static <T, U> T coalesceLazy(T a, Function<U, T> fb, U b) {
-    return a != null ? a : fb.apply(b);
+  public static <T, U> T coalesceLazy(T a, Supplier<T> fb) {
+    return a != null ? a : fb.get();
   }
 
   public static <T> T coalesce(T a, T b, T c) {
     return a != null ? a : b != null ? b : c;
   }
 
-  public static <T, U> T coalesceLazy(T a, Function<U, T> fb, U b, Function<U, T> fc, U c) {
+  public static <T, U> T coalesceLazy(T a, Supplier<T> fb, Supplier<T> fc) {
     if (a != null) {
       return a;
     }
-    T r = fb.apply(b);
+    T r = fb.get();
     if (r != null) {
       return r;
     }
-    return fc.apply(c);
+    return fc.get();
   }
 
   public static <T> T coalesce(T a, T b, T c, T d) {
@@ -44,28 +44,27 @@ public class Utils {
     return a != null ? a : b != null ? b : c != null ? c : d != null ? d : e != null ? e : f;
   }
 
-  public static <T, U> T coalesceLazy(T a, Function<U, T> fb, U b, Function<U, T> fc, U c, Function<U, T> fd, U d,
-    Function<U, T> fe, U e, Function<U, T> ff, U f) {
+  public static <T, U> T coalesceLazy(T a, Supplier<T> fb, Supplier<T> fc, Supplier<T> fd, Supplier<T> fe, Supplier<T> ff) {
     if (a != null) {
       return a;
     }
-    T r = fb.apply(b);
+    T r = fb.get();
     if (r != null) {
       return r;
     }
-    r = fc.apply(c);
+    r = fc.get();
     if (r != null) {
       return r;
     }
-    r = fd.apply(d);
+    r = fd.get();
     if (r != null) {
       return r;
     }
-    r = fe.apply(e);
+    r = fe.get();
     if (r != null) {
       return r;
     }
-    return ff.apply(f);
+    return ff.get();
   }
 
   /** Boxes {@code a} into an {@link Integer}, or {@code null} if {@code a} is {@code nullValue}. */

--- a/src/main/java/org/openmaptiles/util/Utils.java
+++ b/src/main/java/org/openmaptiles/util/Utils.java
@@ -2,6 +2,7 @@ package org.openmaptiles.util;
 
 import com.onthegomap.planetiler.util.Parse;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Common utilities for working with data and the OpenMapTiles schema in {@code layers} implementations.
@@ -12,8 +13,23 @@ public class Utils {
     return a != null ? a : b;
   }
 
+  public static <T, U> T coalesceF(T a, Function<U, T> fb, U b) {
+    return a != null ? a : fb.apply(b);
+  }
+
   public static <T> T coalesce(T a, T b, T c) {
     return a != null ? a : b != null ? b : c;
+  }
+
+  public static <T, U> T coalesceF(T a, Function<U, T> fb, U b, Function<U, T> fc, U c) {
+    if (a != null) {
+      return a;
+    }
+    T r = fb.apply(b);
+    if (r != null) {
+      return r;
+    }
+    return fc.apply(c);
   }
 
   public static <T> T coalesce(T a, T b, T c, T d) {
@@ -26,6 +42,30 @@ public class Utils {
 
   public static <T> T coalesce(T a, T b, T c, T d, T e, T f) {
     return a != null ? a : b != null ? b : c != null ? c : d != null ? d : e != null ? e : f;
+  }
+
+  public static <T, U> T coalesceF(T a, Function<U, T> fb, U b, Function<U, T> fc, U c, Function<U, T> fd, U d,
+    Function<U, T> fe, U e, Function<U, T> ff, U f) {
+    if (a != null) {
+      return a;
+    }
+    T r = fb.apply(b);
+    if (r != null) {
+      return r;
+    }
+    r = fc.apply(c);
+    if (r != null) {
+      return r;
+    }
+    r = fd.apply(d);
+    if (r != null) {
+      return r;
+    }
+    r = fe.apply(e);
+    if (r != null) {
+      return r;
+    }
+    return ff.apply(f);
   }
 
   /** Boxes {@code a} into an {@link Integer}, or {@code null} if {@code a} is {@code nullValue}. */

--- a/src/main/java/org/openmaptiles/util/Utils.java
+++ b/src/main/java/org/openmaptiles/util/Utils.java
@@ -13,7 +13,7 @@ public class Utils {
     return a != null ? a : b;
   }
 
-  public static <T, U> T coalesceF(T a, Function<U, T> fb, U b) {
+  public static <T, U> T coalesceLazy(T a, Function<U, T> fb, U b) {
     return a != null ? a : fb.apply(b);
   }
 
@@ -21,7 +21,7 @@ public class Utils {
     return a != null ? a : b != null ? b : c;
   }
 
-  public static <T, U> T coalesceF(T a, Function<U, T> fb, U b, Function<U, T> fc, U c) {
+  public static <T, U> T coalesceLazy(T a, Function<U, T> fb, U b, Function<U, T> fc, U c) {
     if (a != null) {
       return a;
     }
@@ -44,7 +44,7 @@ public class Utils {
     return a != null ? a : b != null ? b : c != null ? c : d != null ? d : e != null ? e : f;
   }
 
-  public static <T, U> T coalesceF(T a, Function<U, T> fb, U b, Function<U, T> fc, U c, Function<U, T> fd, U d,
+  public static <T, U> T coalesceLazy(T a, Function<U, T> fb, U b, Function<U, T> fc, U c, Function<U, T> fd, U d,
     Function<U, T> fe, U e, Function<U, T> ff, U f) {
     if (a != null) {
       return a;

--- a/src/test/java/org/openmaptiles/layers/BuildingTest.java
+++ b/src/test/java/org/openmaptiles/layers/BuildingTest.java
@@ -1,8 +1,10 @@
 package org.openmaptiles.layers;
 
+import static com.onthegomap.planetiler.TestUtils.newPoint;
 import static com.onthegomap.planetiler.TestUtils.rectangle;
 
 import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SimpleFeature;
@@ -11,8 +13,10 @@ import com.onthegomap.planetiler.reader.osm.OsmReader;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openmaptiles.OpenMapTilesProfile;
+import org.openmaptiles.generated.Tables;
 
 class BuildingTest extends AbstractLayerTest {
 
@@ -175,5 +179,36 @@ class BuildingTest extends AbstractLayerTest {
       "building:building", "yes",
       "building:colour", "#ff0000"
     ))));
+  }
+
+  @Disabled
+  @Test
+  void coalesceFInBuildingProcessBenchmark() {
+    /* The point is to hit Building.process hard (hence @Disabled annotation), measure time and see whether transition
+     * from `coalesce()` to `coalesceF()` helps tpo achieve shorter time. In theory, it should since half of calls of
+     * `parseDoubleOrNull()` should be avoided if firs value (say `height`) is not null thus lambda for second value
+     * (`parseDoubleOrNull` for say `buildingheight`) is not called.
+     *
+     * Values for this UT:
+     * a) before (with `coalesce()`): 3.690s, 3.638s, 3.577s
+     * b) after (with `coalesceF()`:  2.564s, 2.436s, 2.458s
+     *
+     * Values for Slovakia tiles generation:
+     * a) before: Finished in 5m40s cpu:28m38s gc:10s avg:5.1; ... 5m38s cpu:28m52s gc:9s avg:5.1; ... 5m30s cpu:28m16s gc:9s avg:5.1
+     * b) after:  Finished in 4m53s cpu:28m3s gc:8s avg:5.7;   ... 4m45s cpu:27m11s gc:8s avg:5.7; ... 4m44s cpu:27m8s gc:8s avg:5.7
+     */
+    PlanetilerConfig config = PlanetilerConfig.defaults();
+    Building building = new Building(null, config, null);
+    var sourceFeature = SimpleFeature.create(newPoint(0, 0), Map.of("abc", "123"), "source", "source_layer", 99);
+    Tables.OsmBuildingPolygon element = new Tables.OsmBuildingPolygon(
+      null, null, null,
+      null, "3661", "3662",
+      null, null, "3663",
+      "3664", "3665", "3666", sourceFeature
+    );
+
+    for (long i = 0; i < 10_000_000; i++) {
+      building.process(element, null);
+    }
   }
 }

--- a/src/test/java/org/openmaptiles/util/UtilsTest.java
+++ b/src/test/java/org/openmaptiles/util/UtilsTest.java
@@ -1,0 +1,43 @@
+package org.openmaptiles.util;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UtilsTest {
+
+  private record TestRecord(String value) {}
+
+  private int counter2 = 0;
+  private int counter3 = 0;
+  private int counter4 = 0;
+  private int counter5 = 0;
+  private int counter6 = 0;
+
+  @BeforeEach
+  public void setup() {
+    counter2 = 0;
+    counter3 = 0;
+    counter4 = 0;
+    counter5 = 0;
+    counter6 = 0;
+  }
+
+  @Test
+  public void coalesce2L() {
+    Function<TestRecord, Double> r2d = (TestRecord s) -> {
+      counter2++;
+      return Double.valueOf(s.value());
+    };
+
+    TestRecord a = new TestRecord("1");
+    TestRecord b = new TestRecord("2");
+
+    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), r2d, b));
+    Assertions.assertEquals(0, counter2);
+
+    Assertions.assertEquals(2, Utils.coalesceF(null, r2d, b));
+    Assertions.assertEquals(1, counter2);
+  }
+}

--- a/src/test/java/org/openmaptiles/util/UtilsTest.java
+++ b/src/test/java/org/openmaptiles/util/UtilsTest.java
@@ -25,8 +25,8 @@ public class UtilsTest {
   }
 
   @Test
-  public void coalesce2L() {
-    Function<TestRecord, Double> r2d = (TestRecord s) -> {
+  public void coalesceF2() {
+    Function<TestRecord, Double> fb = (TestRecord s) -> {
       counter2++;
       return Double.valueOf(s.value());
     };
@@ -34,10 +34,111 @@ public class UtilsTest {
     TestRecord a = new TestRecord("1");
     TestRecord b = new TestRecord("2");
 
-    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), r2d, b));
+    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), fb, b));
     Assertions.assertEquals(0, counter2);
 
-    Assertions.assertEquals(2, Utils.coalesceF(null, r2d, b));
+    Assertions.assertEquals(2, Utils.coalesceF(null, fb, b));
     Assertions.assertEquals(1, counter2);
+  }
+
+  @Test
+  public void coalesceF3() {
+    Function<TestRecord, Double> fb = (TestRecord s) -> {
+      counter2++;
+      return s == null ? null : Double.valueOf(s.value());
+    };
+    Function<TestRecord, Double> fc = (TestRecord s) -> {
+      counter3++;
+      return Double.valueOf(s.value());
+    };
+
+    TestRecord a = new TestRecord("1");
+    TestRecord b = new TestRecord("2");
+    TestRecord c = new TestRecord("3");
+
+    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), fb, b, fc, c));
+    Assertions.assertEquals(0, counter2);
+    Assertions.assertEquals(0, counter3);
+
+    Assertions.assertEquals(2, Utils.coalesceF(null, fb, b, fc, c));
+    Assertions.assertEquals(1, counter2);
+    Assertions.assertEquals(0, counter3);
+
+    Assertions.assertEquals(3, Utils.coalesceF(null, fb, null, fc, c));
+    Assertions.assertEquals(2, counter2);
+    Assertions.assertEquals(1, counter3);
+  }
+
+  @Test
+  public void coalesceF6() {
+    Function<TestRecord, Double> fb = (TestRecord s) -> {
+      counter2++;
+      return s == null ? null : Double.valueOf(s.value());
+    };
+    Function<TestRecord, Double> fc = (TestRecord s) -> {
+      counter3++;
+      return s == null ? null : Double.valueOf(s.value());
+    };
+    Function<TestRecord, Double> fd = (TestRecord s) -> {
+      counter4++;
+      return s == null ? null : Double.valueOf(s.value());
+    };
+    Function<TestRecord, Double> fe = (TestRecord s) -> {
+      counter5++;
+      return s == null ? null : Double.valueOf(s.value());
+    };
+    Function<TestRecord, Double> ff = (TestRecord s) -> {
+      counter6++;
+      return s == null ? null : Double.valueOf(s.value());
+    };
+
+    TestRecord a = new TestRecord("1");
+    TestRecord b = new TestRecord("2");
+    TestRecord c = new TestRecord("3");
+    TestRecord d = new TestRecord("4");
+    TestRecord e = new TestRecord("5");
+    TestRecord f = new TestRecord("6");
+
+    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), fb, b, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(0, counter2);
+    Assertions.assertEquals(0, counter3);
+    Assertions.assertEquals(0, counter4);
+    Assertions.assertEquals(0, counter5);
+    Assertions.assertEquals(0, counter6);
+
+    Assertions.assertEquals(2, Utils.coalesceF(null, fb, b, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(1, counter2);
+    Assertions.assertEquals(0, counter3);
+    Assertions.assertEquals(0, counter4);
+    Assertions.assertEquals(0, counter5);
+    Assertions.assertEquals(0, counter6);
+
+    Assertions.assertEquals(3, Utils.coalesceF(null, fb, null, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(2, counter2);
+    Assertions.assertEquals(1, counter3);
+    Assertions.assertEquals(0, counter4);
+    Assertions.assertEquals(0, counter5);
+    Assertions.assertEquals(0, counter6);
+
+    Assertions.assertEquals(4, Utils.coalesceF(null, fb, null, fc, null, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(3, counter2);
+    Assertions.assertEquals(2, counter3);
+    Assertions.assertEquals(1, counter4);
+    Assertions.assertEquals(0, counter5);
+    Assertions.assertEquals(0, counter6);
+
+    Assertions.assertEquals(5, Utils.coalesceF(null, fb, null, fc, null, fd, null, fe, e, ff, f));
+    Assertions.assertEquals(4, counter2);
+    Assertions.assertEquals(3, counter3);
+    Assertions.assertEquals(2, counter4);
+    Assertions.assertEquals(1, counter5);
+    Assertions.assertEquals(0, counter6);
+
+    Assertions.assertEquals(6, Utils.coalesceF(null, fb, null, fc, null, fd, null, fe, null, ff, f));
+    Assertions.assertEquals(5, counter2);
+    Assertions.assertEquals(4, counter3);
+    Assertions.assertEquals(3, counter4);
+    Assertions.assertEquals(2, counter5);
+    Assertions.assertEquals(1, counter6);
   }
 }

--- a/src/test/java/org/openmaptiles/util/UtilsTest.java
+++ b/src/test/java/org/openmaptiles/util/UtilsTest.java
@@ -34,10 +34,10 @@ public class UtilsTest {
     TestRecord a = new TestRecord("1");
     TestRecord b = new TestRecord("2");
 
-    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), fb, b));
+    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), () -> fb.apply(b)));
     Assertions.assertEquals(0, counter2);
 
-    Assertions.assertEquals(2, Utils.coalesceLazy(null, fb, b));
+    Assertions.assertEquals(2, Utils.coalesceLazy(null, () -> fb.apply(b)));
     Assertions.assertEquals(1, counter2);
   }
 
@@ -56,15 +56,27 @@ public class UtilsTest {
     TestRecord b = new TestRecord("2");
     TestRecord c = new TestRecord("3");
 
-    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), fb, b, fc, c));
+    Assertions.assertEquals(1, Utils.coalesceLazy(
+        Double.valueOf(a.value()),
+        () -> fb.apply(b),
+        () -> fc.apply(c)
+    ));
     Assertions.assertEquals(0, counter2);
     Assertions.assertEquals(0, counter3);
 
-    Assertions.assertEquals(2, Utils.coalesceLazy(null, fb, b, fc, c));
+    Assertions.assertEquals(2, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(b),
+        () -> fc.apply(c)
+    ));
     Assertions.assertEquals(1, counter2);
     Assertions.assertEquals(0, counter3);
 
-    Assertions.assertEquals(3, Utils.coalesceLazy(null, fb, null, fc, c));
+    Assertions.assertEquals(3, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(null),
+        () -> fc.apply(c)
+    ));
     Assertions.assertEquals(2, counter2);
     Assertions.assertEquals(1, counter3);
   }
@@ -99,42 +111,84 @@ public class UtilsTest {
     TestRecord e = new TestRecord("5");
     TestRecord f = new TestRecord("6");
 
-    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), fb, b, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(1, Utils.coalesceLazy(
+        Double.valueOf(a.value()),
+        () -> fb.apply(b),
+        () -> fc.apply(c),
+        () -> fd.apply(d),
+        () -> fe.apply(e),
+        () -> ff.apply(f)
+    ));
     Assertions.assertEquals(0, counter2);
     Assertions.assertEquals(0, counter3);
     Assertions.assertEquals(0, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(2, Utils.coalesceLazy(null, fb, b, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(2, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(b),
+        () -> fc.apply(c),
+        () -> fd.apply(d),
+        () -> fe.apply(e),
+        () -> ff.apply(f)
+    ));
     Assertions.assertEquals(1, counter2);
     Assertions.assertEquals(0, counter3);
     Assertions.assertEquals(0, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(3, Utils.coalesceLazy(null, fb, null, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(3, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(null),
+        () -> fc.apply(c),
+        () -> fd.apply(d),
+        () -> fe.apply(e),
+        () -> ff.apply(f)
+    ));
     Assertions.assertEquals(2, counter2);
     Assertions.assertEquals(1, counter3);
     Assertions.assertEquals(0, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(4, Utils.coalesceLazy(null, fb, null, fc, null, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(4, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(null),
+        () -> fc.apply(null),
+        () -> fd.apply(d),
+        () -> fe.apply(e),
+        () -> ff.apply(f)
+    ));
     Assertions.assertEquals(3, counter2);
     Assertions.assertEquals(2, counter3);
     Assertions.assertEquals(1, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(5, Utils.coalesceLazy(null, fb, null, fc, null, fd, null, fe, e, ff, f));
+    Assertions.assertEquals(5, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(null),
+        () -> fc.apply(null),
+        () -> fd.apply(null),
+        () -> fe.apply(e),
+        () -> ff.apply(f)
+    ));
     Assertions.assertEquals(4, counter2);
     Assertions.assertEquals(3, counter3);
     Assertions.assertEquals(2, counter4);
     Assertions.assertEquals(1, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(6, Utils.coalesceLazy(null, fb, null, fc, null, fd, null, fe, null, ff, f));
+    Assertions.assertEquals(6, Utils.coalesceLazy(
+        null,
+        () -> fb.apply(null),
+        () -> fc.apply(null),
+        () -> fd.apply(null),
+        () -> fe.apply(null),
+        () -> ff.apply(f)
+    ));
     Assertions.assertEquals(5, counter2);
     Assertions.assertEquals(4, counter3);
     Assertions.assertEquals(3, counter4);

--- a/src/test/java/org/openmaptiles/util/UtilsTest.java
+++ b/src/test/java/org/openmaptiles/util/UtilsTest.java
@@ -25,7 +25,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void coalesceF2() {
+  public void coalesceLazy2() {
     Function<TestRecord, Double> fb = (TestRecord s) -> {
       counter2++;
       return Double.valueOf(s.value());
@@ -34,15 +34,15 @@ public class UtilsTest {
     TestRecord a = new TestRecord("1");
     TestRecord b = new TestRecord("2");
 
-    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), fb, b));
+    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), fb, b));
     Assertions.assertEquals(0, counter2);
 
-    Assertions.assertEquals(2, Utils.coalesceF(null, fb, b));
+    Assertions.assertEquals(2, Utils.coalesceLazy(null, fb, b));
     Assertions.assertEquals(1, counter2);
   }
 
   @Test
-  public void coalesceF3() {
+  public void coalesceLazy3() {
     Function<TestRecord, Double> fb = (TestRecord s) -> {
       counter2++;
       return s == null ? null : Double.valueOf(s.value());
@@ -56,21 +56,21 @@ public class UtilsTest {
     TestRecord b = new TestRecord("2");
     TestRecord c = new TestRecord("3");
 
-    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), fb, b, fc, c));
+    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), fb, b, fc, c));
     Assertions.assertEquals(0, counter2);
     Assertions.assertEquals(0, counter3);
 
-    Assertions.assertEquals(2, Utils.coalesceF(null, fb, b, fc, c));
+    Assertions.assertEquals(2, Utils.coalesceLazy(null, fb, b, fc, c));
     Assertions.assertEquals(1, counter2);
     Assertions.assertEquals(0, counter3);
 
-    Assertions.assertEquals(3, Utils.coalesceF(null, fb, null, fc, c));
+    Assertions.assertEquals(3, Utils.coalesceLazy(null, fb, null, fc, c));
     Assertions.assertEquals(2, counter2);
     Assertions.assertEquals(1, counter3);
   }
 
   @Test
-  public void coalesceF6() {
+  public void coalesceLazy6() {
     Function<TestRecord, Double> fb = (TestRecord s) -> {
       counter2++;
       return s == null ? null : Double.valueOf(s.value());
@@ -99,42 +99,42 @@ public class UtilsTest {
     TestRecord e = new TestRecord("5");
     TestRecord f = new TestRecord("6");
 
-    Assertions.assertEquals(1, Utils.coalesceF(Double.valueOf(a.value()), fb, b, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(1, Utils.coalesceLazy(Double.valueOf(a.value()), fb, b, fc, c, fd, d, fe, e, ff, f));
     Assertions.assertEquals(0, counter2);
     Assertions.assertEquals(0, counter3);
     Assertions.assertEquals(0, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(2, Utils.coalesceF(null, fb, b, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(2, Utils.coalesceLazy(null, fb, b, fc, c, fd, d, fe, e, ff, f));
     Assertions.assertEquals(1, counter2);
     Assertions.assertEquals(0, counter3);
     Assertions.assertEquals(0, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(3, Utils.coalesceF(null, fb, null, fc, c, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(3, Utils.coalesceLazy(null, fb, null, fc, c, fd, d, fe, e, ff, f));
     Assertions.assertEquals(2, counter2);
     Assertions.assertEquals(1, counter3);
     Assertions.assertEquals(0, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(4, Utils.coalesceF(null, fb, null, fc, null, fd, d, fe, e, ff, f));
+    Assertions.assertEquals(4, Utils.coalesceLazy(null, fb, null, fc, null, fd, d, fe, e, ff, f));
     Assertions.assertEquals(3, counter2);
     Assertions.assertEquals(2, counter3);
     Assertions.assertEquals(1, counter4);
     Assertions.assertEquals(0, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(5, Utils.coalesceF(null, fb, null, fc, null, fd, null, fe, e, ff, f));
+    Assertions.assertEquals(5, Utils.coalesceLazy(null, fb, null, fc, null, fd, null, fe, e, ff, f));
     Assertions.assertEquals(4, counter2);
     Assertions.assertEquals(3, counter3);
     Assertions.assertEquals(2, counter4);
     Assertions.assertEquals(1, counter5);
     Assertions.assertEquals(0, counter6);
 
-    Assertions.assertEquals(6, Utils.coalesceF(null, fb, null, fc, null, fd, null, fe, null, ff, f));
+    Assertions.assertEquals(6, Utils.coalesceLazy(null, fb, null, fc, null, fd, null, fe, null, ff, f));
     Assertions.assertEquals(5, counter2);
     Assertions.assertEquals(4, counter3);
     Assertions.assertEquals(3, counter4);


### PR DESCRIPTION
This PR adds `coalesceF()` implementations into `org.openmaptiles.util.Utils` with "F" meaning "function". The main point is as follows:

* currently there are calls like `Double height = coalesce(parseDoubleOrNull(element.height()), parseDoubleOrNull(element.buildingheight()));`
* assumptions:
  * `parseDoubleOrNull()` is non trivial in a sense "quite a lot of operations, especially given the amount of repeated calls it might be getting"
  * second call is useless if first call returns non-null value
* hence the idea to pass the second parameter as "function" which gets called only when the value is actually needed

I was at first skeptical, but did the changes anyway, as a means of getting acquainted with the code better.

Observations after that are, that generating tiles fro Slovakia now takes roughly 10% less time, i.e. instead of around 5:30 it takes around 4:45.

Please take a look and let me know.