### PR TITLE
Require minimum java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,12 +36,9 @@ jobs:
         jdk: [ 17 ]
         include:
           - os: ubuntu-latest
-            jdk: 16
-          - os: ubuntu-latest
             jdk: 18
           - os: ubuntu-latest
-            jdk: 17
-            args: "-DargLine='-Duser.language=fr -Duser.country=FR'"
+            jdk: 19
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Using pre-built docker image:
 docker run -v "$(pwd)/data":/data openmaptiles/planetiler-openmaptiles:latest --force --download --area=monaco
 ```
 
-Or to build from source, after [installing Java 16+](https://adoptium.net/installation.html):
+Or to build from source, after [installing Java 17+](https://adoptium.net/installation.html):
 
 ```bash
 # Build the project (use mvnw.cmd on windows):

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>16</maven.compiler.source>
-    <maven.compiler.target>16</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <planetiler.version>0.6-SNAPSHOT</planetiler.version>
     <junit.version>5.9.2</junit.version>
 
@@ -140,7 +140,7 @@
         </executions>
       </plugin>
 
-      <!-- require building with jdk 16 -->
+      <!-- require building with jdk 17 -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -154,7 +154,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>16</version>
+                  <version>17</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Support for Java 16 ended over a year ago. Switch to requiring minimum java 17 and also run tests against java 19 in CI.