### PR TITLE
Metadata table

### DIFF
--- a/src/test/java/org/openmaptiles/OpenMapTilesTest.java
+++ b/src/test/java/org/openmaptiles/OpenMapTilesTest.java
@@ -76,7 +76,7 @@ class OpenMapTilesTest {
 
   @Test
   void testMetadata() {
-    Map<String, String> metadata = mbtiles.metadata().getAll();
+    Map<String, String> metadata = mbtiles.metadataTable().getAll();
     assertEquals("OpenMapTiles", metadata.get("name"));
     assertEquals("0", metadata.get("minzoom"));
     assertEquals("14", metadata.get("maxzoom"));

--- a/src/test/java/org/openmaptiles/util/VerifyMonacoTest.java
+++ b/src/test/java/org/openmaptiles/util/VerifyMonacoTest.java
@@ -44,7 +44,7 @@ class VerifyMonacoTest {
   @Test
   void testStilInvalidWithOneTile() throws IOException {
     mbtiles.createTablesWithIndexes();
-    mbtiles.metadata().setName("name");
+    mbtiles.metadataTable().setMetadata("name", "name");
     try (var writer = mbtiles.newBatchedTileWriter()) {
       VectorTile tile = new VectorTile();
       tile.addLayerFeatures("layer", List.of(new VectorTile.Feature(


### PR DESCRIPTION
Use `metadataTable` alias in preparation for handling pmtiles/mbtiles metadata generically.