### PR TITLE
Tune Landcover MIN_PIXEL_SIZE_THRESHOLDS to better resemble OpenMapTiles

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Landcover.java
+++ b/src/main/java/org/openmaptiles/layers/Landcover.java
@@ -76,9 +76,8 @@ public class Landcover implements
    */
 
   public static final ZoomFunction<Number> MIN_PIXEL_SIZE_THRESHOLDS = ZoomFunction.fromMaxZoomThresholds(Map.of(
-    13, 8,
-    10, 4,
-    9, 2
+    13, 4,
+    11, 2
   ));
   private static final String TEMP_NUM_POINTS_ATTR = "_numpoints";
   private static final Set<String> WOOD_OR_FOREST = Set.of(

--- a/src/test/java/org/openmaptiles/layers/LandcoverTest.java
+++ b/src/test/java/org/openmaptiles/layers/LandcoverTest.java
@@ -103,7 +103,7 @@ class LandcoverTest extends AbstractLayerTest {
       "_layer", "landcover",
       "subclass", "wood",
       "class", "wood",
-      "_minpixelsize", 8d,
+      "_minpixelsize", 4d,
       "_numpointsattr", "_numpoints",
       "_minzoom", 7,
       "_maxzoom", 14
@@ -114,7 +114,7 @@ class LandcoverTest extends AbstractLayerTest {
       "_layer", "landcover",
       "subclass", "forest",
       "class", "wood",
-      "_minpixelsize", 8d,
+      "_minpixelsize", 4d,
       "_minzoom", 7,
       "_maxzoom", 14
     )), process(polygonFeature(Map.of(
@@ -124,7 +124,7 @@ class LandcoverTest extends AbstractLayerTest {
       "_layer", "landcover",
       "subclass", "dune",
       "class", "sand",
-      "_minpixelsize", 4d,
+      "_minpixelsize", 2d,
       "_minzoom", 7,
       "_maxzoom", 14
     )), process(polygonFeature(Map.of(


### PR DESCRIPTION
I'm fine if this is not accepted, but I spotted differences compared to OpenMapTiles and it seems that this tunes it to be sufficiently similar. It does make the output about 10% larger (tested on Slovenia).

For reference attaching a screenshot what this is fixing (left OpenMapTiles, right Planetiler before the fix)
![Screenshot 2023-08-02 at 14 11 11](https://github.com/openmaptiles/planetiler-openmaptiles/assets/805384/1d6af065-3f64-47a3-a6f5-9922db0d780a)
