### PR TITLE
onthegomap/planetiler#379 - download dir config

### DIFF
--- a/src/main/java/org/openmaptiles/OpenMapTilesMain.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesMain.java
@@ -16,7 +16,7 @@ public class OpenMapTilesMain {
 
   static void run(Arguments arguments) throws Exception {
     Path dataDir = Path.of("data");
-    Path sourcesDir = dataDir.resolve("sources");
+    Path sourcesDir = arguments.file("download_dir", "download directory", dataDir.resolve("sources"));
     // use --area=... argument, AREA=... env var or area=... in config to set the region of the world to use
     // will be ignored if osm_path or osm_url are set
     String area = arguments.getString(


### PR DESCRIPTION
allow to configure the download dir
=> users can use a central/shared location

notes:
- it's probaly best to setup an environment variable if users whish to use a central one: PLANETILER_DOWNLOAD_DIR=/home/<user>/.planetiler/downloads
- when wiki data is used, one probably wants to always download wiki data (--fetch-wikidata) This is because only the required data for an area is fetched. It's worth mentioning here that data is only downloaded if it doesn't exist already, and existing entries are maintained (cache).