### PR TITLE
Deduplicate and remove limit on concurrent routes

### DIFF
--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -57,8 +57,10 @@ import com.onthegomap.planetiler.util.Translations;
 import com.onthegomap.planetiler.util.ZoomFunction;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
@@ -111,14 +113,6 @@ public class TransportationName implements
     .put(9, 8_000)
     .put(10, 8_000)
     .put(11, 8_000);
-  private static final List<String> CONCURRENT_ROUTE_KEYS = List.of(
-    Fields.ROUTE_1,
-    Fields.ROUTE_2,
-    Fields.ROUTE_3,
-    Fields.ROUTE_4,
-    Fields.ROUTE_5,
-    Fields.ROUTE_6
-  );
   private final boolean brunnel;
   private final boolean sizeForShield;
   private final boolean limitMerge;
@@ -273,11 +267,13 @@ public class TransportationName implements
       .setSortKey(element.zOrder())
       .setMinZoom(minzoom);
 
-    // populate route_1, route_2, ... tags
-    for (int i = 0; i < Math.min(CONCURRENT_ROUTE_KEYS.size(), relations.size()); i++) {
-      Transportation.RouteRelation routeRelation = relations.get(i);
-      feature.setAttr(CONCURRENT_ROUTE_KEYS.get(i), routeRelation.network() == null ? null :
-        routeRelation.network() + "=" + coalesce(routeRelation.ref(), ""));
+    // populate route_1, route_2, ... route_n tags and remove duplicates
+    Set<String> routes = new HashSet<>();
+    for (var route : relations) {
+      String routeString = route.network() + "=" + coalesce(route.ref(), "");
+      if (routes.add(routeString)) {
+        feature.setAttr("route_" + routes.size(), routeString);
+      }
     }
 
     if (brunnel) {

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -11,7 +11,9 @@ import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
+import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import com.onthegomap.planetiler.stats.Stats;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -379,6 +381,46 @@ class TransportationTest extends AbstractLayerTest {
       "route_1", "US:I=95",
       "route_2", "US:NJ:NJTP=NJTP",
       "_minzoom", 6
+    )), rendered);
+  }
+
+  @Test
+  void testSegmentWithManyRoutes() {
+    List<OsmRelationInfo> relations = new ArrayList<>();
+    for (int route = 1; route <= 16; route++) {
+      int num = (route + 1) / 2; // to make dups
+      var rel = new OsmElement.Relation(route);
+      rel.setTag("type", "route");
+      rel.setTag("route", "road");
+      rel.setTag("network", "US:I");
+      rel.setTag("ref", Integer.toString(num));
+      rel.setTag("name", "Route " + num);
+      relations.addAll(profile.preprocessOsmRelation(rel));
+    }
+
+    FeatureCollector rendered = process(lineFeatureWithRelation(
+      relations,
+      Map.of(
+        "highway", "motorway",
+        "name", "New Jersey Turnpike",
+        "ref", "I 95;NJTP"
+      )));
+
+    assertFeatures(13, List.of(mapOf(
+      "_layer", "transportation",
+      "class", "motorway",
+      "_minzoom", 4
+    ), mapOf(
+      "_layer", "transportation_name",
+      "route_1", "US:I=1",
+      "route_2", "US:I=2",
+      "route_3", "US:I=3",
+      "route_4", "US:I=4",
+      "route_5", "US:I=5",
+      "route_6", "US:I=6",
+      "route_7", "US:I=7",
+      "route_8", "US:I=8",
+      "route_9", "<null>"
     )), rendered);
   }
 


### PR DESCRIPTION
Fixes #115 and #95 by deduplicating concurrent routes and also removing the limit on the number that can show up on a road segment.