### PR TITLE
fix missing name:xx for roads in transportation_name (#58)

### DIFF
--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -121,9 +121,11 @@ public class TransportationName implements
   private Transportation transportation;
   private final LongByteMap motorwayJunctionHighwayClasses = Hppc.newLongByteHashMap();
   private final LongSet motorwayJunctionNodes = new LongHashSet();
+  private final Translations translations;
 
   public TransportationName(Translations translations, PlanetilerConfig config, Stats stats) {
     this.config = config;
+    this.translations = translations;
     this.brunnel = config.arguments().getBoolean(
       "transportation_name_brunnel",
       "transportation_name layer: set to false to omit brunnel and help merge long highways",
@@ -195,7 +197,7 @@ public class TransportationName implements
 
         features.point(LAYER_NAME)
           .setBufferPixels(BUFFER_SIZE)
-          .putAttrs(OmtLanguageUtils.getNamesWithoutTranslations(element.source().tags()))
+          .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
           .setAttr(Fields.REF, ref)
           .setAttr(Fields.REF_LENGTH, ref != null ? ref.length() : null)
           .setAttr(Fields.CLASS, highwayClass(cls.highwayValue, null, null, null))
@@ -255,7 +257,7 @@ public class TransportationName implements
       .setBufferPixels(BUFFER_SIZE)
       .setBufferPixelOverrides(MIN_LENGTH)
       // TODO abbreviate road names - can't port osml10n because it is AGPL
-      .putAttrs(OmtLanguageUtils.getNamesWithoutTranslations(element.source().tags()))
+      .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
       .setAttr(Fields.REF, ref)
       .setAttr(Fields.REF_LENGTH, ref != null ? ref.length() : null)
       .setAttr(Fields.NETWORK,
@@ -305,7 +307,7 @@ public class TransportationName implements
       features.line(LAYER_NAME)
         .setBufferPixels(BUFFER_SIZE)
         .setBufferPixelOverrides(MIN_LENGTH)
-        .putAttrs(OmtLanguageUtils.getNamesWithoutTranslations(element.source().tags()))
+        .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
         .setAttr(Fields.CLASS, "aerialway")
         .setAttr(Fields.SUBCLASS, element.aerialway())
         .setMinPixelSize(0)
@@ -320,7 +322,7 @@ public class TransportationName implements
       features.line(LAYER_NAME)
         .setBufferPixels(BUFFER_SIZE)
         .setBufferPixelOverrides(MIN_LENGTH)
-        .putAttrs(OmtLanguageUtils.getNamesWithoutTranslations(element.source().tags()))
+        .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
         .setAttr(Fields.CLASS, element.shipway())
         .setMinPixelSize(0)
         .setSortKey(element.zOrder())

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -1357,4 +1357,30 @@ class TransportationTest extends AbstractLayerTest {
       "service", "driveway"
     ))));
   }
+
+  @Test
+  void testIssue58() {
+    // test subject: https://www.openstreetmap.org/way/222564359
+    // note: "name:es" used instead of "name:ar" since we've setup only "de" and "es" for unit tests
+    FeatureCollector result = process(lineFeature(Map.of(
+        "name", "איילון דרום",
+        "name:es", "أيالون جنوب",
+        "name:en", "Ayalon South",
+        "highway", "motorway"
+    )));
+    assertFeatures(4, List.of(Map.of(
+        "_layer", "transportation",
+        "_type", "line",
+        "class", "motorway"
+    ), Map.of(
+        "_layer", "transportation_name",
+        "_type", "line",
+        "class", "motorway",
+        "name", "איילון דרום",
+        "name_int", "Ayalon South",
+        "name:latin", "Ayalon South",
+        "name:es", "أيالون جنوب",
+        "name:en", "Ayalon South"
+    )), result);
+  }
 }

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -1363,24 +1363,24 @@ class TransportationTest extends AbstractLayerTest {
     // test subject: https://www.openstreetmap.org/way/222564359
     // note: "name:es" used instead of "name:ar" since we've setup only "de" and "es" for unit tests
     FeatureCollector result = process(lineFeature(Map.of(
-        "name", "איילון דרום",
-        "name:es", "أيالون جنوب",
-        "name:en", "Ayalon South",
-        "highway", "motorway"
+      "name", "איילון דרום",
+      "name:es", "أيالون جنوب",
+      "name:en", "Ayalon South",
+      "highway", "motorway"
     )));
     assertFeatures(4, List.of(Map.of(
-        "_layer", "transportation",
-        "_type", "line",
-        "class", "motorway"
+      "_layer", "transportation",
+      "_type", "line",
+      "class", "motorway"
     ), Map.of(
-        "_layer", "transportation_name",
-        "_type", "line",
-        "class", "motorway",
-        "name", "איילון דרום",
-        "name_int", "Ayalon South",
-        "name:latin", "Ayalon South",
-        "name:es", "أيالون جنوب",
-        "name:en", "Ayalon South"
+      "_layer", "transportation_name",
+      "_type", "line",
+      "class", "motorway",
+      "name", "איילון דרום",
+      "name_int", "Ayalon South",
+      "name:latin", "Ayalon South",
+      "name:es", "أيالون جنوب",
+      "name:en", "Ayalon South"
     )), result);
   }
 }


### PR DESCRIPTION
Fixes #58 the way suggested by @JPapir .

Screenshot for the location mentioned in the issue by @ZeLonewolf :

![Screenshot from 2023-11-08 10-45-14](https://github.com/openmaptiles/planetiler-openmaptiles/assets/115141505/addaecd5-e523-4683-b78b-c4fe2db182ab)
