### PR TITLE
Set Docker image creation timestamp to latest git commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
   </dependencies>
 
+  <scm>
+    <connection>scm:git:https://github.com/openmaptiles/planetiler-openmaptiles.git</connection>
+    <url>https://github.com/openmaptiles/planetiler-openmaptiles</url>
+  </scm>
+
   <build>
     <plugins>
       <plugin>
@@ -203,26 +208,21 @@
 
       <!-- Make latest git commit timestamp available to jib  -->
       <plugin>
-          <groupId>io.github.git-commit-id</groupId>
-          <artifactId>git-commit-id-maven-plugin</artifactId>
-          <version>7.0.0</version>
-          <executions>
-              <execution>
-                  <id>get-the-git-infos</id>
-                  <goals>
-                      <goal>revision</goal>
-                  </goals>
-                  <phase>initialize</phase>
-              </execution>
-          </executions>
-          <configuration>
-              <dateFormat>yyyy-MM-dd'T'HH:mm:ss'Z'</dateFormat>
-              <dateFormatTimeZone>GMT</dateFormatTimeZone>
-              <generateGitPropertiesFile>false</generateGitPropertiesFile>
-              <includeOnlyProperties>
-                  <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
-              </includeOnlyProperties>
-          </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doCheck>false</doCheck>
+          <doUpdate>false</doUpdate>
+        </configuration>
       </plugin>
 
       <!-- Create a runnable container -->
@@ -252,8 +252,8 @@
               </org.opencontainers.image.source>
             </labels>
             <mainClass>${mainClass}</mainClass>
-            <creationTime>${git.commit.time}</creationTime>
-            <filesModificationTime>${git.commit.time}</filesModificationTime>
+            <creationTime>${maven.build.timestamp}</creationTime>
+            <filesModificationTime>${maven.build.timestamp}</filesModificationTime>
           </container>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,30 @@
         </executions>
       </plugin>
 
+      <!-- Make latest git commit timestamp available to jib  -->
+      <plugin>
+          <groupId>io.github.git-commit-id</groupId>
+          <artifactId>git-commit-id-maven-plugin</artifactId>
+          <version>7.0.0</version>
+          <executions>
+              <execution>
+                  <id>get-the-git-infos</id>
+                  <goals>
+                      <goal>revision</goal>
+                  </goals>
+                  <phase>initialize</phase>
+              </execution>
+          </executions>
+          <configuration>
+              <dateFormat>yyyy-MM-dd'T'HH:mm:ss'Z'</dateFormat>
+              <dateFormatTimeZone>GMT</dateFormatTimeZone>
+              <generateGitPropertiesFile>false</generateGitPropertiesFile>
+              <includeOnlyProperties>
+                  <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
+              </includeOnlyProperties>
+          </configuration>
+      </plugin>
+
       <!-- Create a runnable container -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
@@ -228,6 +252,8 @@
               </org.opencontainers.image.source>
             </labels>
             <mainClass>${mainClass}</mainClass>
+            <creationTime>${git.commit.time}</creationTime>
+            <filesModificationTime>${git.commit.time}</filesModificationTime>
           </container>
         </configuration>
       </plugin>


### PR DESCRIPTION
Minor detail, but it bugged me that the Docker image timestamp was set to the Unix epoch. So this sets it to the timestamp of the latest git commit.

I'm pretty ignorant about Java ecosystem stuff, so let me know if this is wrong / not helpful / whatever, or needs any adjustment.

Thanks for the amazing project!