### PR TITLE
Set feature IDs in boundary and agg_stop features.

### DIFF
--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -151,12 +151,12 @@ public class OpenMapTilesProfile extends ForwardingProfile {
   public boolean caresAboutWikidataTranslation(OsmElement elem) {
     var tags = elem.tags();
     if (elem instanceof OsmElement.Node) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POINT, tags, 0), false);
+      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POINT, tags), false);
     } else if (elem instanceof OsmElement.Way) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags, 0), false) ||
-        wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_LINE, tags, 0), false);
+      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false) ||
+        wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_LINE, tags), false);
     } else if (elem instanceof OsmElement.Relation) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags, 0), false);
+      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false);
     } else {
       return false;
     }

--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -151,12 +151,12 @@ public class OpenMapTilesProfile extends ForwardingProfile {
   public boolean caresAboutWikidataTranslation(OsmElement elem) {
     var tags = elem.tags();
     if (elem instanceof OsmElement.Node) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POINT, tags), false);
+      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POINT, tags, 0), false);
     } else if (elem instanceof OsmElement.Way) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false) ||
-        wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_LINE, tags), false);
+      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags, 0), false) ||
+        wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_LINE, tags, 0), false);
     } else if (elem instanceof OsmElement.Relation) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false);
+      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags, 0), false);
     } else {
       return false;
     }

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -269,6 +269,7 @@ public class Boundary implements
           // save for later
           try {
             CountryBoundaryComponent component = new CountryBoundaryComponent(
+              feature.id(),
               minAdminLevel,
               disputed,
               maritime,
@@ -323,7 +324,7 @@ public class Boundary implements
           if (merged instanceof LineString lineString) {
             BorderingRegions borderingRegions = getBorderingRegions(countryBoundaries, key.regions, lineString);
 
-            var features = featureCollectors.get(SimpleFeature.fromWorldGeometry(lineString));
+            var features = featureCollectors.get(SimpleFeature.fromWorldGeometry(lineString, key.id));
             var newFeature = features.line(LAYER_NAME).setBufferPixels(BUFFER_SIZE)
               .setAttr(Fields.ADMIN_LEVEL, key.adminLevel)
               .setAttr(Fields.DISPUTED, key.disputed ? 1 : 0)
@@ -471,6 +472,7 @@ public class Boundary implements
    * Information to hold onto from processing a way in a boundary relation to determine the left/right region ID later.
    */
   private record CountryBoundaryComponent(
+    long id,
     int adminLevel,
     boolean disputed,
     boolean maritime,
@@ -482,7 +484,7 @@ public class Boundary implements
   ) {
 
     CountryBoundaryComponent groupingKey() {
-      return new CountryBoundaryComponent(adminLevel, disputed, maritime, minzoom, null, regions, claimedBy, name);
+      return new CountryBoundaryComponent(id, adminLevel, disputed, maritime, minzoom, null, regions, claimedBy, name);
     }
   }
 }

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -176,7 +176,8 @@ public class Poi implements
   private void processAggStop(Tables.OsmPoiPoint element, FeatureCollector.Factory featureCollectors,
     Consumer<FeatureCollector.Feature> emit, Integer aggStop) {
     try {
-      var features = featureCollectors.get(SimpleFeature.fromWorldGeometry(element.source().worldGeometry()));
+      var features =
+        featureCollectors.get(SimpleFeature.fromWorldGeometry(element.source().worldGeometry(), element.source().id()));
       setupPoiFeature(element, features.point(LAYER_NAME), aggStop);
       for (var feature : features) {
         emit.accept(feature);
@@ -209,7 +210,6 @@ public class Poi implements
           processAggStop(aggStopSet.getFirst(), featureCollectors, emit, 1);
           continue;
         }
-
         Tables.OsmPoiPoint nearest = null;
         try {
           // find most important stops based on subclass
@@ -228,7 +228,8 @@ public class Poi implements
           double minDistance = Double.MAX_VALUE;
           for (var aggStop : topAggStops) {
             double distance = aggStopCentroid.distance(aggStop.source().worldGeometry());
-            if (distance < minDistance) {
+            if (distance < minDistance || nearest == null ||
+              (distance == minDistance && aggStop.source().id() < nearest.source().id())) {
               minDistance = distance;
               nearest = aggStop;
             }


### PR DESCRIPTION
Use https://github.com/onthegomap/planetiler/pull/791 to set IDs explicitly on synthetic boundary and POI features that are created during the boundary and agg_stop post-processing routines so that the output is consistent for the same input.