### PR TITLE
Ambiguity in _Example adding an attribute to a built-in layer_

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the [layers package](src/main/java/org/openmaptiles/layers), and make a change t
 Example adding an attribute to a built-in layer
 </summary>
 
-For example to copy over the source attribute from OpenStreetMap elements to the building layer,
+For example to copy over the name attribute from OpenStreetMap elements to the building layer,
 modify [Building.java](src/main/java/org/openmaptiles/layers/Building.java):
 
 ```diff
@@ -53,7 +53,7 @@ modify [Building.java](src/main/java/org/openmaptiles/layers/Building.java):
          .setAttrWithMinzoom(Fields.RENDER_MIN_HEIGHT, renderMinHeight, 14)
          .setAttrWithMinzoom(Fields.COLOUR, color, 14)
          .setAttrWithMinzoom(Fields.HIDE_3D, hide3d, 14)
-+        .setAttrWithMinzoom("source", element.source().getTag("source"), 14)
++        .setAttrWithMinzoom("name", element.source().getTag("name"), 14)
          .setSortKey(renderHeight);
        if (mergeZ13Buildings) {
          feature


### PR DESCRIPTION
The current example adds the "source" attribute to the Building layer. Unfortunately, `source()` is also a name of a method used in the code. The method name should not be changed if a different attribute is needed. 

If a naive developer, who wants to add the "name" attribute,  replace all instances of `source` with `name`

```diff
@@ -166,6 +166,7 @@ public class Building implements
         .setAttrWithMinzoom(Fields.RENDER_MIN_HEIGHT, renderMinHeight, 14)
         .setAttrWithMinzoom(Fields.COLOUR, color, 14)
         .setAttrWithMinzoom(Fields.HIDE_3D, hide3d, 14)
+        .setAttrWithMinzoom("name", element.name().getTag("name"), 14)
         .setSortKey(renderHeight);
       if (mergeZ13Buildings) {
         feature
```

a compilation error is produced

```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] .../planetiler-openmaptiles/src/main/java/org/openmaptiles/layers/Building.java:[169,44] cannot find symbol
  symbol:   method name()
  location: variable element of type org.openmaptiles.generated.Tables.OsmBuildingPolygon
```

To clarify the matters, this PR adds the attribute "name" that differs from any method in the additional line.