### PR TITLE
Do not create RowDispatch if list of handlers is empty

### DIFF
--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -120,6 +120,9 @@ public class OpenMapTilesProfile extends ForwardingProfile {
             return handler;
           })
           .toList();
+        if (handlers.isEmpty()) {
+          return null;
+        }
         return new RowDispatch(constructor.create(), handlers);
       }).simplify().indexAndWarn();
     wikidataMappings = Tables.MAPPINGS


### PR DESCRIPTION
This requires https://github.com/onthegomap/planetiler/pull/822 .

E.g. if we run for example `java ... --only-layers=water ...` Planetiler skips OSM processing since such data is not needed for `water` layer, thus speeding up work when one is troubleshooting only that one particular layer.

Fixes https://github.com/onthegomap/planetiler/issues/823 .