### PR TITLE
Reduce buffer on transportation_name layer

### DIFF
--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -113,11 +113,6 @@ public class TransportationName implements
     .put(9, 8_000)
     .put(10, 4_000)
     .put(11, 2_000);
-  private static final ZoomFunction<Number> BUFFER_PIXEL_OVERRIDES =
-    ZoomFunction.fromMaxZoomThresholds(Map.of(
-      13, 256,
-      6, 256
-    ));
   private final boolean brunnel;
   private final boolean sizeForShield;
   private final boolean limitMerge;
@@ -260,7 +255,7 @@ public class TransportationName implements
 
     FeatureCollector.Feature feature = features.line(LAYER_NAME)
       .setBufferPixels(BUFFER_SIZE)
-      .setBufferPixelOverrides(BUFFER_PIXEL_OVERRIDES)
+      .setBufferPixelOverrides(MIN_LENGTH)
       // TODO abbreviate road names - can't port osml10n because it is AGPL
       .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
       .setAttr(Fields.REF, ref)
@@ -321,7 +316,7 @@ public class TransportationName implements
     if (!nullOrEmpty(element.name())) {
       features.line(LAYER_NAME)
         .setBufferPixels(BUFFER_SIZE)
-        .setBufferPixelOverrides(BUFFER_PIXEL_OVERRIDES)
+        .setBufferPixelOverrides(MIN_LENGTH)
         .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
         .setAttr(Fields.CLASS, "aerialway")
         .setAttr(Fields.SUBCLASS, element.aerialway())
@@ -336,7 +331,7 @@ public class TransportationName implements
     if (!nullOrEmpty(element.name())) {
       features.line(LAYER_NAME)
         .setBufferPixels(BUFFER_SIZE)
-        .setBufferPixelOverrides(BUFFER_PIXEL_OVERRIDES)
+        .setBufferPixelOverrides(MIN_LENGTH)
         .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
         .setAttr(Fields.CLASS, element.shipway())
         .setMinPixelSize(0)


### PR DESCRIPTION
I noticed recently that temp disk usage went from ~200GB to ~400GB when generating the planet with openmaptiles profile and traced it to #144 which included https://github.com/phanecak-maptiler/planetiler-openmaptiles/pull/28 that increased the buffer size on transportation name layer.  This change reverts https://github.com/phanecak-maptiler/planetiler-openmaptiles/pull/28 since I don't think it has any impact on tile output ([before](https://private-user-images.githubusercontent.com/115141505/286227524-2ae45c9a-75b8-4b11-bde4-15b9e1806cbd.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTQ2OTczMDEsIm5iZiI6MTcxNDY5NzAwMSwicGF0aCI6Ii8xMTUxNDE1MDUvMjg2MjI3NTI0LTJhZTQ1YzlhLTc1YjgtNGIxMS1iZGU0LTE1YjllMTgwNmNiZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNTAzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDUwM1QwMDQzMjFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05ZTQyMTJjYTJlNTMwMmVkZTY2ZmNlNmU3NmRlZjQyMzFmZGFkMGUxNDVhNjU2MDkwOWYwMTAzMDRlOWJmMjk2JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.rdaUI-3fmDb7FbOY3_zLzbP6KpLMFZlN6FZ_gO_L9AA) and [after](https://private-user-images.githubusercontent.com/115141505/289640301-34386527-4561-4aad-9ee3-6c26c402256e.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTQ2OTczMDEsIm5iZiI6MTcxNDY5NzAwMSwicGF0aCI6Ii8xMTUxNDE1MDUvMjg5NjQwMzAxLTM0Mzg2NTI3LTQ1NjEtNGFhZC05ZWUzLTZjMjZjNDAyMjU2ZS5qcGc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNTAzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDUwM1QwMDQzMjFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00ODA0N2NjYTZkYjgwMTQ2YmM2Y2JlNmY0OTM2OTdkZTAyNzhiOGI1N2I2OWRhMmJmNzZjMTI3NTdmNDAwZDZhJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.w-heJ_3DA5QLGKDKWENGUu1dJSXvgbg08mTnwC5u5x0) images appear identical)