### PR TITLE
Fix maven commands

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,10 +48,10 @@ jobs:
       # Skip spotless since that gets checked in a separate task
       - name: Build with mvnw (linux/mac)
         if: ${{ !contains(matrix.os, 'windows') }}
-        run: ./mvnw ${{matrix.args}} -Dspotless.check.skip --batch-mode -no-transfer-progress package verify jib:buildTar --file pom.xml
+        run: ./mvnw ${{matrix.args}} -Dspotless.check.skip --batch-mode -no-transfer-progress verify jib:buildTar --file pom.xml
       - name: Build with mvnw.cmd (windows)
         if: ${{ contains(matrix.os, 'windows') }}
-        run: mvnw.cmd ${{matrix.args}} -Dspotless.check.skip --batch-mode -no-transfer-progress package verify jib:buildTar --file pom.xml
+        run: mvnw.cmd ${{matrix.args}} -Dspotless.check.skip --batch-mode -no-transfer-progress verify jib:buildTar --file pom.xml
         shell: cmd
 
   regenerate:
@@ -127,7 +127,7 @@ jobs:
           cache: 'maven'
       - name: Build and test this branch
         working-directory: planetiler
-        run: ./mvnw -Dimage.version=CI_ONLY --batch-mode -no-transfer-progress verify package jib:dockerBuild --file pom.xml
+        run: ./mvnw -Dimage.version=CI_ONLY --batch-mode -no-transfer-progress verify jib:dockerBuild --file pom.xml
       - name: 'Download data (java)'
         working-directory: planetiler
         run: java -jar planetiler-dist/target/*with-deps.jar --only-download --area=monaco


### PR DESCRIPTION
`mvn package verify` is redundant and causes issues with newer versions of built tools, so switch to `mvn verify` which runs both goals.