### PR TITLE
Address warnings and deprecations

### DIFF
--- a/src/main/java/org/openmaptiles/Generate.java
+++ b/src/main/java/org/openmaptiles/Generate.java
@@ -604,16 +604,16 @@ public class Generate {
    * "class") based on the "field mapping" defined in the layer schema definition.
    */
   static MultiExpression<String> generateFieldMapping(JsonNode valuesNode) {
-    MultiExpression<String> mapping = MultiExpression.of(new ArrayList<>());
+    List<MultiExpression.Entry<String>> mappings = new ArrayList<>();
     valuesNode.fields().forEachRemaining(entry -> {
       String field = entry.getKey();
       JsonNode node = entry.getValue();
       Expression expression = or(parseFieldMappingExpression(node).toList()).simplify();
       if (!expression.equals(or()) && !expression.equals(and())) {
-        mapping.expressions().add(MultiExpression.entry(field, expression));
+        mappings.add(MultiExpression.entry(field, expression));
       }
     });
-    return mapping;
+    return MultiExpression.of(mappings);
   }
 
   private static Stream<Expression> parseFieldMappingExpression(JsonNode node) {

--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -143,7 +143,7 @@ public class OpenMapTilesProfile extends ForwardingProfile {
   }
 
   /** Returns the imposm3 table row constructors that match an input element's tags. */
-  private List<MultiExpression.Match<RowDispatch>> getTableMatches(SourceFeature input) {
+  public List<MultiExpression.Match<RowDispatch>> getTableMatches(SourceFeature input) {
     return osmMappings.getMatchesWithTriggers(input);
   }
 
@@ -262,7 +262,7 @@ public class OpenMapTilesProfile extends ForwardingProfile {
    */
   public interface IgnoreWikidata {}
 
-  private record RowDispatch(
+  public record RowDispatch(
     Tables.Constructor constructor,
     List<Tables.RowHandler<Tables.Row>> handlers
   ) {}

--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -41,7 +41,7 @@ import org.openmaptiles.layers.TransportationName;
  * </ul>
  * Layers can also subscribe to notifications when we finished processing an input source by implementing
  * {@link FinishHandler} or post-process features in that layer before rendering the output tile by implementing
- * {@link FeaturePostProcessor}.
+ * {@link LayerPostProcesser}.
  */
 public class OpenMapTilesProfile extends ForwardingProfile {
 
@@ -133,7 +133,7 @@ public class OpenMapTilesProfile extends ForwardingProfile {
       registerSourceHandler(OSM_SOURCE, (source, features) -> {
         for (var match : getTableMatches(source)) {
           RowDispatch rowDispatch = match.match();
-          var row = rowDispatch.constructor.create(source, match.keys().get(0));
+          var row = rowDispatch.constructor.create(source, match.keys().getFirst());
           for (Tables.RowHandler<Tables.Row> handler : rowDispatch.handlers()) {
             handler.process(row, features);
           }
@@ -143,23 +143,20 @@ public class OpenMapTilesProfile extends ForwardingProfile {
   }
 
   /** Returns the imposm3 table row constructors that match an input element's tags. */
-  public List<MultiExpression.Match<RowDispatch>> getTableMatches(SourceFeature input) {
+  private List<MultiExpression.Match<RowDispatch>> getTableMatches(SourceFeature input) {
     return osmMappings.getMatchesWithTriggers(input);
   }
 
   @Override
   public boolean caresAboutWikidataTranslation(OsmElement elem) {
     var tags = elem.tags();
-    if (elem instanceof OsmElement.Node) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POINT, tags), false);
-    } else if (elem instanceof OsmElement.Way) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false) ||
+    return switch (elem) {
+      case OsmElement.Node ignored -> wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POINT, tags), false);
+      case OsmElement.Way ignored -> wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false) ||
         wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_LINE, tags), false);
-    } else if (elem instanceof OsmElement.Relation) {
-      return wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false);
-    } else {
-      return false;
-    }
+      case OsmElement.Relation ignored -> wikidataMappings.getOrElse(SimpleFeature.create(EMPTY_POLYGON, tags), false);
+      default -> false;
+    };
   }
 
   /*

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -44,6 +44,7 @@ import static java.util.stream.Collectors.groupingBy;
 import com.carrotsearch.hppc.LongObjectMap;
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -95,11 +96,11 @@ import org.slf4j.LoggerFactory;
 public class Boundary implements
   OpenMapTilesSchema.Boundary,
   OpenMapTilesProfile.NaturalEarthProcessor,
-  OpenMapTilesProfile.OsmRelationPreprocessor,
+  ForwardingProfile.OsmRelationPreprocessor,
   OpenMapTilesProfile.OsmAllProcessor,
   Tables.OsmBoundaryPolygon.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor,
-  OpenMapTilesProfile.FinishHandler {
+  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.FinishHandler {
 
   /*
    * Uses natural earth at lower zoom levels and OpenStreetMap at higher zoom levels.

--- a/src/main/java/org/openmaptiles/layers/Building.java
+++ b/src/main/java/org/openmaptiles/layers/Building.java
@@ -42,6 +42,7 @@ import static org.openmaptiles.util.Utils.coalesce;
 
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeometryException;
@@ -53,7 +54,6 @@ import com.onthegomap.planetiler.util.Translations;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 
@@ -67,8 +67,8 @@ import org.openmaptiles.generated.Tables;
 public class Building implements
   OpenMapTilesSchema.Building,
   Tables.OsmBuildingPolygon.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor,
-  OpenMapTilesProfile.OsmRelationPreprocessor {
+  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.OsmRelationPreprocessor {
 
   /*
    * Emit all buildings from OSM data at z14.

--- a/src/main/java/org/openmaptiles/layers/Housenumber.java
+++ b/src/main/java/org/openmaptiles/layers/Housenumber.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
 public class Housenumber implements
   OpenMapTilesSchema.Housenumber,
   Tables.OsmHousenumberPoint.Handler,
-  ForwardingProfile.FeaturePostProcessor {
+  ForwardingProfile.LayerPostProcesser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Housenumber.class);
   private static final String OSM_SEPARATOR = ";";
@@ -75,7 +75,7 @@ public class Housenumber implements
   private static final String TEMP_PARTITION = "_partition";
   private static final String TEMP_HAS_NAME = "_has_name";
   private static final Comparator<VectorTile.Feature> BY_TEMP_HAS_NAME = Comparator
-    .comparing(i -> (Boolean) i.attrs().get(TEMP_HAS_NAME), Boolean::compare);
+    .comparing(i -> (Boolean) i.tags().get(TEMP_HAS_NAME), Boolean::compare);
   private final Stats stats;
 
   public Housenumber(Translations translations, PlanetilerConfig config, Stats stats) {
@@ -144,7 +144,7 @@ public class Housenumber implements
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> list) throws GeometryException {
     // remove duplicate house numbers, features without name tag are prioritized
     var items = list.stream()
-      .collect(Collectors.groupingBy(f -> f.attrs().get(TEMP_PARTITION)))
+      .collect(Collectors.groupingBy(f -> f.tags().get(TEMP_PARTITION)))
       .values().stream()
       .flatMap(
         g -> g.stream().min(BY_TEMP_HAS_NAME).stream()
@@ -153,8 +153,8 @@ public class Housenumber implements
 
     // remove temporary attributes
     for (var item : items) {
-      item.attrs().remove(TEMP_HAS_NAME);
-      item.attrs().remove(TEMP_PARTITION);
+      item.tags().remove(TEMP_HAS_NAME);
+      item.tags().remove(TEMP_PARTITION);
     }
 
     // reduces the size of some heavy z14 tiles with many repeated housenumber values by 60% or more

--- a/src/main/java/org/openmaptiles/layers/Landcover.java
+++ b/src/main/java/org/openmaptiles/layers/Landcover.java
@@ -37,6 +37,7 @@ package org.openmaptiles.layers;
 
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.expression.MultiExpression;
@@ -65,7 +66,7 @@ public class Landcover implements
   OpenMapTilesSchema.Landcover,
   OpenMapTilesProfile.NaturalEarthProcessor,
   Tables.OsmLandcoverPolygon.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor {
+  ForwardingProfile.LayerPostProcesser {
 
   /*
    * Large ice areas come from natural earth and the rest come from OpenStreetMap at higher zoom
@@ -138,7 +139,7 @@ public class Landcover implements
   public List<VectorTile.Feature> postProcess(int zoom, List<VectorTile.Feature> items) throws GeometryException {
     if (zoom < 7 || zoom > 13) {
       for (var item : items) {
-        item.attrs().remove(TEMP_NUM_POINTS_ATTR);
+        item.tags().remove(TEMP_NUM_POINTS_ATTR);
       }
       return items;
     } else { // z7-13
@@ -176,7 +177,7 @@ public class Landcover implements
       }
       var merged = FeatureMerge.mergeOverlappingPolygons(toMerge, 4);
       for (var item : merged) {
-        item.attrs().remove(tempGroupKey);
+        item.tags().remove(tempGroupKey);
       }
       result.addAll(merged);
       return result;

--- a/src/main/java/org/openmaptiles/layers/Landuse.java
+++ b/src/main/java/org/openmaptiles/layers/Landuse.java
@@ -40,6 +40,7 @@ import static org.openmaptiles.util.Utils.nullIfEmpty;
 
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeometryException;
@@ -67,7 +68,7 @@ import org.openmaptiles.generated.Tables;
 public class Landuse implements
   OpenMapTilesSchema.Landuse,
   OpenMapTilesProfile.NaturalEarthProcessor,
-  OpenMapTilesProfile.FeaturePostProcessor,
+  ForwardingProfile.LayerPostProcesser,
   Tables.OsmLandusePolygon.Handler {
 
   private static final ZoomFunction<Number> MIN_PIXEL_SIZE_THRESHOLDS = ZoomFunction.fromMaxZoomThresholds(Map.of(
@@ -137,7 +138,7 @@ public class Landuse implements
     List<VectorTile.Feature> toMerge = new ArrayList<>();
     List<VectorTile.Feature> result = new ArrayList<>();
     for (var item : items) {
-      if (FieldValues.CLASS_RESIDENTIAL.equals(item.attrs().get(Fields.CLASS))) {
+      if (FieldValues.CLASS_RESIDENTIAL.equals(item.tags().get(Fields.CLASS))) {
         toMerge.add(item);
       } else {
         result.add(item);

--- a/src/main/java/org/openmaptiles/layers/MountainPeak.java
+++ b/src/main/java/org/openmaptiles/layers/MountainPeak.java
@@ -40,6 +40,7 @@ import static org.openmaptiles.util.Utils.nullIfEmpty;
 
 import com.carrotsearch.hppc.LongIntMap;
 import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -74,7 +75,7 @@ public class MountainPeak implements
   OpenMapTilesSchema.MountainPeak,
   Tables.OsmPeakPoint.Handler,
   Tables.OsmMountainLinestring.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor {
+  ForwardingProfile.LayerPostProcesser {
 
   /*
    * Mountain peaks come from OpenStreetMap data and are ranked by importance (based on if they
@@ -180,8 +181,8 @@ public class MountainPeak implements
       // now that we have accurate ranks, remove anything outside the desired buffer
       if (!insideTileBuffer(feature)) {
         items.set(i, null);
-      } else if (!feature.attrs().containsKey(Fields.RANK)) {
-        feature.attrs().put(Fields.RANK, gridrank);
+      } else if (!feature.tags().containsKey(Fields.RANK)) {
+        feature.tags().put(Fields.RANK, gridrank);
       }
     }
     return items;
@@ -196,7 +197,7 @@ public class MountainPeak implements
       Geometry geom = feature.geometry().decode();
       return !(geom instanceof Point point) || (insideTileBuffer(point.getX()) && insideTileBuffer(point.getY()));
     } catch (GeometryException e) {
-      e.log(stats, "mountain_peak_decode_point", "Error decoding mountain peak point: " + feature.attrs());
+      e.log(stats, "mountain_peak_decode_point", "Error decoding mountain peak point: " + feature.tags());
       return false;
     }
   }

--- a/src/main/java/org/openmaptiles/layers/Park.java
+++ b/src/main/java/org/openmaptiles/layers/Park.java
@@ -42,6 +42,7 @@ import static org.openmaptiles.util.Utils.nullIfEmpty;
 import com.carrotsearch.hppc.LongIntMap;
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -53,7 +54,6 @@ import com.onthegomap.planetiler.util.SortKey;
 import com.onthegomap.planetiler.util.Translations;
 import java.util.List;
 import java.util.Locale;
-import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
@@ -68,17 +68,12 @@ import org.openmaptiles.util.OmtLanguageUtils;
 public class Park implements
   OpenMapTilesSchema.Park,
   Tables.OsmParkPolygon.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor {
-
-  // constants for packing the minimum zoom ordering of park labels into the sort-key field
-  private static final int PARK_NATIONAL_PARK_BOOST = 1 << (SORT_KEY_BITS - 1);
-  private static final int PARK_WIKIPEDIA_BOOST = 1 << (SORT_KEY_BITS - 2);
+  ForwardingProfile.LayerPostProcesser {
 
   // constants for determining the minimum zoom level for a park label based on its area
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =
     Math.pow(GeoUtils.metersToPixelAtEquator(0, Math.sqrt(70_000)) / 256d, 2);
   private static final double LOG2 = Math.log(2);
-  private static final int PARK_AREA_RANGE = 1 << (SORT_KEY_BITS - 3);
   private static final double SMALLEST_PARK_WORLD_AREA = Math.pow(4, -26); // 2^14 tiles, 2^12 pixels per tile
 
   private final Translations translations;
@@ -149,7 +144,7 @@ public class Park implements
     for (VectorTile.Feature feature : items) {
       if (feature.geometry().geomType() == GeometryType.POINT && feature.hasGroup()) {
         int count = counts.getOrDefault(feature.group(), 0) + 1;
-        feature.attrs().put("rank", count);
+        feature.tags().put("rank", count);
         counts.put(feature.group(), count);
       }
     }

--- a/src/main/java/org/openmaptiles/layers/Place.java
+++ b/src/main/java/org/openmaptiles/layers/Place.java
@@ -42,6 +42,7 @@ import static org.openmaptiles.util.Utils.nullOrEmpty;
 
 import com.carrotsearch.hppc.LongIntMap;
 import com.onthegomap.planetiler.FeatureCollector;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -89,7 +90,7 @@ public class Place implements
   Tables.OsmIslandPolygon.Handler,
   Tables.OsmCityPoint.Handler,
   Tables.OsmBoundaryPolygon.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor {
+  ForwardingProfile.LayerPostProcesser {
 
   /*
    * Place labels locations and names come from OpenStreetMap, but we also join with natural
@@ -396,8 +397,8 @@ public class Place implements
     for (VectorTile.Feature feature : items) {
       int gridrank = groupCounts.getOrDefault(feature.group(), 1);
       groupCounts.put(feature.group(), gridrank + 1);
-      if (!feature.attrs().containsKey(Fields.RANK)) {
-        feature.attrs().put(Fields.RANK, 10 + gridrank);
+      if (!feature.tags().containsKey(Fields.RANK)) {
+        feature.tags().put(Fields.RANK, 10 + gridrank);
       }
     }
     return items;

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -80,8 +80,8 @@ public class Poi implements
   OpenMapTilesSchema.Poi,
   Tables.OsmPoiPoint.Handler,
   Tables.OsmPoiPolygon.Handler,
-  ForwardingProfile.FeaturePostProcessor,
-  OpenMapTilesProfile.FinishHandler {
+  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.FinishHandler {
 
   /*
    * process() creates the raw POI feature from OSM elements and postProcess()
@@ -331,8 +331,8 @@ public class Poi implements
     for (VectorTile.Feature feature : items) {
       int gridrank = groupCounts.getOrDefault(feature.group(), 1);
       groupCounts.put(feature.group(), gridrank + 1);
-      if (!feature.attrs().containsKey(Fields.RANK)) {
-        feature.attrs().put(Fields.RANK, gridrank);
+      if (!feature.tags().containsKey(Fields.RANK)) {
+        feature.tags().put(Fields.RANK, gridrank);
       }
     }
     return items;

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -43,6 +43,7 @@ import static org.openmaptiles.util.Utils.*;
 
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.expression.MultiExpression;
@@ -93,8 +94,8 @@ public class Transportation implements
   Tables.OsmShipwayLinestring.Handler,
   Tables.OsmHighwayPolygon.Handler,
   OpenMapTilesProfile.NaturalEarthProcessor,
-  OpenMapTilesProfile.FeaturePostProcessor,
-  OpenMapTilesProfile.OsmRelationPreprocessor,
+  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.OsmRelationPreprocessor,
   OpenMapTilesProfile.IgnoreWikidata {
 
   /*
@@ -676,16 +677,16 @@ public class Transportation implements
     // TODO merge preserving oneway instead ignoring
     int onewayId = 1;
     for (var item : items) {
-      var oneway = item.attrs().get(Fields.ONEWAY);
+      var oneway = item.tags().get(Fields.ONEWAY);
       if (oneway instanceof Number n && ONEWAY_VALUES.contains(n.intValue())) {
-        item.attrs().put(LIMIT_MERGE_TAG, onewayId++);
+        item.tags().put(LIMIT_MERGE_TAG, onewayId++);
       }
     }
 
     var merged = FeatureMerge.mergeLineStrings(items, minLength, tolerance, BUFFER_SIZE);
 
     for (var item : merged) {
-      item.attrs().remove(LIMIT_MERGE_TAG);
+      item.tags().remove(LIMIT_MERGE_TAG);
     }
     return merged;
   }

--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -81,7 +81,7 @@ public class TransportationName implements
   Tables.OsmHighwayLinestring.Handler,
   Tables.OsmAerialwayLinestring.Handler,
   Tables.OsmShipwayLinestring.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor,
+  ForwardingProfile.LayerPostProcesser,
   OpenMapTilesProfile.IgnoreWikidata,
   ForwardingProfile.OsmNodePreprocessor,
   ForwardingProfile.OsmWayPreprocessor {
@@ -357,8 +357,8 @@ public class TransportationName implements
     if (limitMerge) {
       // remove temp keys that were just used to improve line merging
       for (var feature : result) {
-        feature.attrs().remove(LINK_TEMP_KEY);
-        feature.attrs().remove(RELATION_ID_TEMP_KEY);
+        feature.tags().remove(LINK_TEMP_KEY);
+        feature.tags().remove(RELATION_ID_TEMP_KEY);
       }
     }
     return result;

--- a/src/main/java/org/openmaptiles/layers/Water.java
+++ b/src/main/java/org/openmaptiles/layers/Water.java
@@ -72,8 +72,8 @@ public class Water implements
   Tables.OsmWaterPolygon.Handler,
   OpenMapTilesProfile.NaturalEarthProcessor,
   OpenMapTilesProfile.OsmWaterPolygonProcessor,
-  ForwardingProfile.FeaturePostProcessor,
-  OpenMapTilesProfile.FinishHandler {
+  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.FinishHandler {
 
   /*
    * At low zoom levels, use natural earth for oceans and major lakes, and at high zoom levels

--- a/src/main/java/org/openmaptiles/layers/Water.java
+++ b/src/main/java/org/openmaptiles/layers/Water.java
@@ -126,7 +126,7 @@ public class Water implements
         if (geom.isValid()) {
           lakeInfo.geom = geom;
         } else {
-          LOGGER.debug("Fixing geometry of NE lake {}", feature.getLong("ne_id"));
+          LOGGER.trace("Fixing geometry of NE lake {}", feature.getLong("ne_id"));
           lakeInfo.geom = GeometryFixer.fix(geom);
         }
         lakeInfo.name = feature.getString("name");
@@ -201,7 +201,7 @@ public class Water implements
     if (!geom.isValid()) {
       geom = GeometryFixer.fix(geom);
       stats.dataError("omt_fix_water_before_ne_intersect");
-      LOGGER.debug("Fixing geometry of OSM element {} before attempt to add ID to natural earth water feature",
+      LOGGER.trace("Fixing geometry of OSM element {} before attempt to add ID to natural earth water feature",
         element.source().id());
     }
 

--- a/src/main/java/org/openmaptiles/layers/Waterway.java
+++ b/src/main/java/org/openmaptiles/layers/Waterway.java
@@ -41,6 +41,7 @@ import com.carrotsearch.hppc.LongObjectHashMap;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.ForwardingProfile;
 import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.collection.Hppc;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
@@ -70,9 +71,9 @@ import org.openmaptiles.util.Utils;
 public class Waterway implements
   OpenMapTilesSchema.Waterway,
   Tables.OsmWaterwayLinestring.Handler,
-  OpenMapTilesProfile.FeaturePostProcessor,
+  ForwardingProfile.LayerPostProcesser,
   OpenMapTilesProfile.NaturalEarthProcessor,
-  OpenMapTilesProfile.OsmRelationPreprocessor,
+  ForwardingProfile.OsmRelationPreprocessor,
   OpenMapTilesProfile.OsmAllProcessor {
 
   /*
@@ -207,7 +208,7 @@ public class Waterway implements
       // remove ways for river relations if relation is not long enough
       double minSizeAtZoom = MIN_PIXEL_LENGTHS.apply(zoom).doubleValue() / Math.pow(2, zoom) / 256d;
       for (int i = 0; i < items.size(); i++) {
-        Object relIdObj = items.get(i).attrs().remove(TEMP_REL_ID_ADDR);
+        Object relIdObj = items.get(i).tags().remove(TEMP_REL_ID_ADDR);
         if (relIdObj instanceof Long relId && riverRelationLengths.get(relId).get() < minSizeAtZoom) {
           items.set(i, null);
         }

--- a/src/test/java/org/openmaptiles/layers/LandcoverTest.java
+++ b/src/test/java/org/openmaptiles/layers/LandcoverTest.java
@@ -203,7 +203,7 @@ class LandcoverTest extends AbstractLayerTest {
     throws GeometryException {
     Assertions.assertEquals(expected,
       profile.postProcessLayerFeatures("landcover", zoom, in).stream().map(
-        VectorTile.Feature::attrs)
+        VectorTile.Feature::tags)
         .toList());
   }
 }


### PR DESCRIPTION
- refer directly to nested classes in ForwardingProfile (instead of through OpenMapTilesProfile)
- use vector tile feature `tags()` method instead of deprecated `attrs()`
- reduce verbosity of bad water polygon logging
- remove some unused variables