### PR TITLE
Use super(config) and caresAboutLayer() in OpenMapTilesProfile ...

### DIFF
--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -60,8 +60,7 @@ public class OpenMapTilesProfile extends ForwardingProfile {
   }
 
   public OpenMapTilesProfile(Translations translations, PlanetilerConfig config, Stats stats) {
-    List<String> onlyLayers = config.arguments().getList("only_layers", "Include only certain layers", List.of());
-    List<String> excludeLayers = config.arguments().getList("exclude_layers", "Exclude certain layers", List.of());
+    super(config);
 
     // register release/finish/feature postprocessor/osm relationship handler methods...
     List<Handler> layers = new ArrayList<>();
@@ -71,7 +70,7 @@ public class OpenMapTilesProfile extends ForwardingProfile {
     var extraLayers = ExtraLayers.create(translations, config, stats);
     var allLayers = Stream.concat(omtLayers.stream(), extraLayers.stream()).toList();
     for (Layer layer : allLayers) {
-      if ((onlyLayers.isEmpty() || onlyLayers.contains(layer.name())) && !excludeLayers.contains(layer.name())) {
+      if (caresAboutLayer(layer)) {
         layers.add(layer);
         registerHandler(layer);
         if (layer instanceof TransportationName transportationName) {


### PR DESCRIPTION
... to make sure we're working with `onlyLayers` and `excludeLayers` in `OpenMapTilesProfile` and `ForwardingProfile` in consistent manner.

Depends on: https://github.com/onthegomap/planetiler/pull/968