### PR TITLE
3.15 was release so snapshot version bumped to 3.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.openmaptiles</groupId>
   <artifactId>planetiler-openmaptiles</artifactId>
-  <version>3.15.0-SNAPSHOT</version>
+  <version>3.15.1-SNAPSHOT</version>
 
   <name>OpenMapTiles Vector Tile Schema implementation for Planetiler tool</name>
 


### PR DESCRIPTION
This relates to https://github.com/onthegomap/planetiler/pull/970

This means that next release may be 3.15.1 (e.g. just minor changes without major impact on generated tiles or schema) or 3.16 (if we do change schema or tiles), possibly even 4.0 (if we do some major changes). Exact version of next release depends on when the release will be done and what kind of changes will be merged in the mean time.

So far we've merged only minor code refactors and dependency updates, hence 3.15.1.

Apart from that we also need this to distinguish a SNAPSHOT version from before 3.15 and SNAPSHOT done after 3.15 otherwise maven and other tools will not recognize the difference and that may cause confusion.