### PR TITLE
use dependsOnLayer() ...

### DIFF
--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -141,6 +141,11 @@ public class OpenMapTilesProfile extends ForwardingProfile {
     }
   }
 
+  @Override
+  public boolean dependsOnLayer(String dependent, String dependency) {
+    return "transportation_name".equals(dependent) && "transportation".equals(dependency);
+  }
+
   /** Returns the imposm3 table row constructors that match an input element's tags. */
   public List<MultiExpression.Match<RowDispatch>> getTableMatches(SourceFeature input) {
     return osmMappings.getMatchesWithTriggers(input);

--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -17,6 +17,7 @@ import com.onthegomap.planetiler.stats.Stats;
 import com.onthegomap.planetiler.util.Translations;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.openmaptiles.addons.ExtraLayers;
 import org.openmaptiles.generated.OpenMapTilesSchema;
@@ -142,8 +143,8 @@ public class OpenMapTilesProfile extends ForwardingProfile {
   }
 
   @Override
-  public boolean dependsOnLayer(String dependent, String dependency) {
-    return "transportation_name".equals(dependent) && "transportation".equals(dependency);
+  public Map<String, List<String>> dependsOnLayer() {
+    return Map.of("transportation_name", List.of("transportation"));
   }
 
   /** Returns the imposm3 table row constructors that match an input element's tags. */


### PR DESCRIPTION
... to make sure `caresAboutLayer()` properly handles the situation when `transportation_name` depends on `transportation` hence:

- <s>when `transportation` is excluded, then also `transportation_name` needs to be also treated as excluded</s>
- when `transportation` is included (e.g. mentioned in `--only-layers`) then `transportation_name` needs to be also treated as included

Depends on: https://github.com/onthegomap/planetiler/pull/991

Fixes bug introduced in #182, which failed to handle dependency of `transportation_name` on `transportation`.