### PR TITLE
Clean-up of `LanguageUtils`

### DIFF
--- a/src/main/java/org/openmaptiles/util/OmtLanguageUtils.java
+++ b/src/main/java/org/openmaptiles/util/OmtLanguageUtils.java
@@ -114,6 +114,14 @@ public class OmtLanguageUtils {
     return result;
   }
 
+  public static String string(Object obj) {
+    return nullIfEmpty(obj == null ? null : obj.toString());
+  }
+
+  public static String transliteratedName(Map<String, Object> tags) {
+    return Translations.transliterate(string(tags.get("name")));
+  }
+
   private static Stream<String> getAllNameTranslationsBesidesEnglishAndGerman(Map<String, Object> tags) {
     return tags.entrySet().stream()
       .filter(e -> !EN_DE_NAME_KEYS.contains(e.getKey()) && VALID_NAME_TAGS.test(e.getKey()))

--- a/src/main/java/org/openmaptiles/util/OmtLanguageUtils.java
+++ b/src/main/java/org/openmaptiles/util/OmtLanguageUtils.java
@@ -126,6 +126,6 @@ public class OmtLanguageUtils {
     return tags.entrySet().stream()
       .filter(e -> !EN_DE_NAME_KEYS.contains(e.getKey()) && VALID_NAME_TAGS.test(e.getKey()))
       .map(Map.Entry::getValue)
-      .map(LanguageUtils::string);
+      .map(OmtLanguageUtils::string);
   }
 }


### PR DESCRIPTION
It looks like that some time ago there was a refactor of the code and some "language stuff" is in `LanguageUtils` in `planetiler-core` and got moved to `OmtLanguageUtils` in `planetiler-openmaptiles`. This PR relies on https://github.com/onthegomap/planetiler/pull/1068 and tries to clean-up some remnants of that:

- Stuff which is used by and only by `OmtLanguageUtils`:
  - `string()`: copied here from `LanguageUtils`
  - `transliteratedName()`: same as above
