### PR TITLE
clean-up, based on recent changes in planetiler-core reg. LayerPostProcesser

### DIFF
--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -42,7 +42,7 @@ import org.openmaptiles.layers.TransportationName;
  * </ul>
  * Layers can also subscribe to notifications when we finished processing an input source by implementing
  * {@link FinishHandler} or post-process features in that layer before rendering the output tile by implementing
- * {@link LayerPostProcesser}.
+ * {@link LayerPostProcessor}.
  */
 public class OpenMapTilesProfile extends ForwardingProfile {
 

--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -99,7 +99,7 @@ public class Boundary implements
   ForwardingProfile.OsmRelationPreprocessor,
   OpenMapTilesProfile.OsmAllProcessor,
   Tables.OsmBoundaryPolygon.Handler,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   ForwardingProfile.FinishHandler {
 
   /*

--- a/src/main/java/org/openmaptiles/layers/Building.java
+++ b/src/main/java/org/openmaptiles/layers/Building.java
@@ -67,7 +67,7 @@ import org.openmaptiles.generated.Tables;
 public class Building implements
   OpenMapTilesSchema.Building,
   Tables.OsmBuildingPolygon.Handler,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   ForwardingProfile.OsmRelationPreprocessor {
 
   /*

--- a/src/main/java/org/openmaptiles/layers/Housenumber.java
+++ b/src/main/java/org/openmaptiles/layers/Housenumber.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
 public class Housenumber implements
   OpenMapTilesSchema.Housenumber,
   Tables.OsmHousenumberPoint.Handler,
-  ForwardingProfile.LayerPostProcesser {
+  ForwardingProfile.LayerPostProcessor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Housenumber.class);
   private static final String OSM_SEPARATOR = ";";

--- a/src/main/java/org/openmaptiles/layers/Landcover.java
+++ b/src/main/java/org/openmaptiles/layers/Landcover.java
@@ -66,7 +66,7 @@ public class Landcover implements
   OpenMapTilesSchema.Landcover,
   OpenMapTilesProfile.NaturalEarthProcessor,
   Tables.OsmLandcoverPolygon.Handler,
-  ForwardingProfile.LayerPostProcesser {
+  ForwardingProfile.LayerPostProcessor {
 
   /*
    * Large ice areas come from natural earth and the rest come from OpenStreetMap at higher zoom

--- a/src/main/java/org/openmaptiles/layers/Landuse.java
+++ b/src/main/java/org/openmaptiles/layers/Landuse.java
@@ -68,7 +68,7 @@ import org.openmaptiles.generated.Tables;
 public class Landuse implements
   OpenMapTilesSchema.Landuse,
   OpenMapTilesProfile.NaturalEarthProcessor,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   Tables.OsmLandusePolygon.Handler {
 
   private static final ZoomFunction<Number> MIN_PIXEL_SIZE_THRESHOLDS = ZoomFunction.fromMaxZoomThresholds(Map.of(

--- a/src/main/java/org/openmaptiles/layers/MountainPeak.java
+++ b/src/main/java/org/openmaptiles/layers/MountainPeak.java
@@ -75,7 +75,7 @@ public class MountainPeak implements
   OpenMapTilesSchema.MountainPeak,
   Tables.OsmPeakPoint.Handler,
   Tables.OsmMountainLinestring.Handler,
-  ForwardingProfile.LayerPostProcesser {
+  ForwardingProfile.LayerPostProcessor {
 
   /*
    * Mountain peaks come from OpenStreetMap data and are ranked by importance (based on if they

--- a/src/main/java/org/openmaptiles/layers/Park.java
+++ b/src/main/java/org/openmaptiles/layers/Park.java
@@ -68,7 +68,7 @@ import org.openmaptiles.util.OmtLanguageUtils;
 public class Park implements
   OpenMapTilesSchema.Park,
   Tables.OsmParkPolygon.Handler,
-  ForwardingProfile.LayerPostProcesser {
+  ForwardingProfile.LayerPostProcessor {
 
   // constants for determining the minimum zoom level for a park label based on its area
   private static final double WORLD_AREA_FOR_70K_SQUARE_METERS =

--- a/src/main/java/org/openmaptiles/layers/Place.java
+++ b/src/main/java/org/openmaptiles/layers/Place.java
@@ -90,7 +90,7 @@ public class Place implements
   Tables.OsmIslandPolygon.Handler,
   Tables.OsmCityPoint.Handler,
   Tables.OsmBoundaryPolygon.Handler,
-  ForwardingProfile.LayerPostProcesser {
+  ForwardingProfile.LayerPostProcessor {
 
   /*
    * Place labels locations and names come from OpenStreetMap, but we also join with natural

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -80,7 +80,7 @@ public class Poi implements
   OpenMapTilesSchema.Poi,
   Tables.OsmPoiPoint.Handler,
   Tables.OsmPoiPolygon.Handler,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   ForwardingProfile.FinishHandler {
 
   /*

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -94,7 +94,7 @@ public class Transportation implements
   Tables.OsmShipwayLinestring.Handler,
   Tables.OsmHighwayPolygon.Handler,
   OpenMapTilesProfile.NaturalEarthProcessor,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   ForwardingProfile.OsmRelationPreprocessor,
   OpenMapTilesProfile.IgnoreWikidata {
 

--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -81,7 +81,7 @@ public class TransportationName implements
   Tables.OsmHighwayLinestring.Handler,
   Tables.OsmAerialwayLinestring.Handler,
   Tables.OsmShipwayLinestring.Handler,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   OpenMapTilesProfile.IgnoreWikidata,
   ForwardingProfile.OsmNodePreprocessor,
   ForwardingProfile.OsmWayPreprocessor {

--- a/src/main/java/org/openmaptiles/layers/Water.java
+++ b/src/main/java/org/openmaptiles/layers/Water.java
@@ -72,7 +72,7 @@ public class Water implements
   Tables.OsmWaterPolygon.Handler,
   OpenMapTilesProfile.NaturalEarthProcessor,
   OpenMapTilesProfile.OsmWaterPolygonProcessor,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   ForwardingProfile.FinishHandler {
 
   /*

--- a/src/main/java/org/openmaptiles/layers/Waterway.java
+++ b/src/main/java/org/openmaptiles/layers/Waterway.java
@@ -71,7 +71,7 @@ import org.openmaptiles.util.Utils;
 public class Waterway implements
   OpenMapTilesSchema.Waterway,
   Tables.OsmWaterwayLinestring.Handler,
-  ForwardingProfile.LayerPostProcesser,
+  ForwardingProfile.LayerPostProcessor,
   OpenMapTilesProfile.NaturalEarthProcessor,
   ForwardingProfile.OsmRelationPreprocessor,
   OpenMapTilesProfile.OsmAllProcessor {


### PR DESCRIPTION
`LayerPostProcesser` replaced with `LayerPostProcessor`

ref: https://github.com/onthegomap/planetiler/pull/1031