### PR TITLE
Extra name tags

### DIFF
--- a/src/main/java/org/openmaptiles/Generate.java
+++ b/src/main/java/org/openmaptiles/Generate.java
@@ -32,6 +32,7 @@ import java.util.TreeMap;
 import java.util.stream.Stream;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
+import org.openmaptiles.util.OmtLanguageUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
@@ -143,6 +144,8 @@ public class Generate {
     // then crawl table definitions from each layers/<layer>/mapping.yaml file that the layer references
     String rootUrl = base + "openmaptiles.yaml";
     OpenmaptilesConfig config = loadAndParseYaml(rootUrl, planetilerConfig, OpenmaptilesConfig.class);
+
+    OmtLanguageUtils.setExtraNameTags(planetilerConfig.extraNameTags());
 
     List<LayerConfig> layers = new ArrayList<>();
     Set<String> imposm3MappingFiles = new LinkedHashSet<>();

--- a/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
+++ b/src/main/java/org/openmaptiles/OpenMapTilesProfile.java
@@ -24,6 +24,7 @@ import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.layers.Transportation;
 import org.openmaptiles.layers.TransportationName;
+import org.openmaptiles.util.OmtLanguageUtils;
 
 /**
  * Delegates the logic for generating a map to individual implementations in the {@code layers} package.
@@ -139,6 +140,10 @@ public class OpenMapTilesProfile extends ForwardingProfile {
           }
         }
       });
+    }
+
+    if (config.extraNameTags() != null && !config.extraNameTags().isEmpty()) {
+      OmtLanguageUtils.setExtraNameTags(config.extraNameTags());
     }
   }
 

--- a/src/test/java/org/openmaptiles/util/OmtLanguageUtilsTest.java
+++ b/src/test/java/org/openmaptiles/util/OmtLanguageUtilsTest.java
@@ -4,6 +4,7 @@ import static com.onthegomap.planetiler.TestUtils.assertSubmap;
 import static com.onthegomap.planetiler.util.LanguageUtils.containsOnlyLatinCharacters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.onthegomap.planetiler.util.Translations;
@@ -262,5 +263,25 @@ class OmtLanguageUtilsTest {
       "name:ja", "ja name osm"
     ));
     assertNull(result.get("name:ja"));
+  }
+
+  @Test
+  void testExtraNameTags() {
+    Map<String, Object> tags = Map.of(
+      "extra", "extra",
+      "name", "name",
+      "name:en", "english name",
+      "name:de", "german name"
+    );
+    assertFalse(
+      OmtLanguageUtils.getNames(tags, translations).containsKey("extra"));
+    try {
+      OmtLanguageUtils.setExtraNameTags(List.of("extra"));
+      assertTrue(
+        OmtLanguageUtils.getNames(tags, translations).containsKey("extra"));
+    }
+    finally {
+      OmtLanguageUtils.setExtraNameTags(List.of());
+    }
   }
 }


### PR DESCRIPTION
Addresses Planetiler issue https://github.com/onthegomap/planetiler/issues/1184.  Adds a `setExtraNameTags` method to `OmtLanguageUtils` and code withing `OmtLanguageUtils.getNames` to copy existing tags specified by `setExtraNameTags` from the source into the result. 

See companion PR for openmaptiles for com.onthegomap.planetiler.config.PlanetilerConfig change that adds `extraNameTags` to `PlanetilerConfig` record, so that `org.openmaptiles.OpenMapTilesProffile  and`org.openmaptiles.Generate` can call `OmtLanguageUtils.setExtraNameTags`

