### PR TITLE
Update README.md about MVT ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ available options.
   or wikipedia page or name)
 - Some line and polygon tolerances are different, can be tweaked with `--simplify-tolerance` parameter
 - For bigger bays whose label points show above Z9, centerline is used for Z9+
+- MVT IDs encoded as `{ID} * 10 + {1 for OSM nodes, 2 for OSM ways, 3 for OSM relations, 0 for any other source}` by default
 
 ## Customizing
 


### PR DESCRIPTION
Regarding resolution here:

> https://github.com/openmaptiles/planetiler-openmaptiles/issues/157#issuecomment-2975496737
> Closed with `{vector tile feature id} = {original ID} * {feature_source_id_multiplier arg value} + {1 for OSM nodes, 2 for OSM ways, 3 for OSM relations, 0 for any other source}` with a default `feature-source-id-multiplier=10`.

I propose to update documentation accordingly.