### PR TITLE
Use planetiler snapshot from new maven url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
     </repository>
     <!-- Get planetiler snapshot builds from here: -->
     <repository>
-      <id>nexus-snapshots</id>
-      <name>Nexus SNAPSHOT Repository</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
Maven switched the URLs used for publishing snapshots (https://central.sonatype.org/pages/ossrh-eol/) so update planetiler-openmaptiles to use that new URL.