### PR TITLE
Add Docker support (#66)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+*.log
+*.tmp
+*.swp
+.vscode/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /app
+COPY .git .git
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn clean package -DskipTests
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=builder /app/target/*-with-deps.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar","--download"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  planetiler-app:
+    build: .
+    container_name: planetiler-app
+    ports:
+      - "8080:8080"
+    restart: unless-stopped


### PR DESCRIPTION
This PR introduces Docker support for planetiler-openmaptiles, making it easier for developers to build, run, and test the application without manual dependency setup. This addresses issue [#66].
Changes:
-Added Dockerfile to containerize the application.
-Added docker-compose.yml to run the app with default configuration.
-Added .dockerignore to optimize build performance and reduce image size.
Benefits:
-Simplifies setup for developers and contributors.
-Ensures a consistent runtime environment across machines.
-Supports quick testing and experimentation without affecting local setups.