### PR TITLE
Planetiler 0.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <planetiler.version>0.9.1</planetiler.version>
+    <planetiler.version>0.9.2-SNAPSHOT</planetiler.version>
     <junit.version>5.13.4</junit.version>
 
     <mainClass>org.openmaptiles.OpenMapTilesMain</mainClass>

--- a/src/test/java/org/openmaptiles/OpenMapTilesTest.java
+++ b/src/test/java/org/openmaptiles/OpenMapTilesTest.java
@@ -198,7 +198,7 @@ class OpenMapTilesTest {
     assertNumFeatures("transportation", Map.of(
       "class", "path",
       "subclass", "footway"
-    ), 14, 756, LineString.class);
+    ), 14, 828, LineString.class);
     assertNumFeatures("transportation", Map.of(
       "class", "primary"
     ), 14, 249, LineString.class);


### PR DESCRIPTION
Update of `planetiler-core` version, but mostly follow-up on https://github.com/onthegomap/planetiler/pull/1330 .

More boundary and transportation lines now make it into tiles. Checked on Monaco and so far look OK, even better:

![Screenshot From 2025-09-18 11-18-06](https://github.com/user-attachments/assets/076ba5db-21e5-4e67-8882-a16b8ad8d45c)
