### PR TITLE
Remove version for snakeyaml dependency

### DIFF
--- a/submodule.pom.xml
+++ b/submodule.pom.xml
@@ -23,7 +23,6 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.33</version>
     </dependency>
     <dependency>
       <groupId>org.commonmark</groupId>


### PR DESCRIPTION
Removed version specification for snakeyaml dependency only for submodule.pom.xml since https://github.com/onthegomap/planetiler/pull/1368 specifies the version explicitly and dependabot was not keeping submodule.pom.xml up to date.