### PR TITLE
Improve name subkey validation

### DIFF
--- a/src/main/java/org/openmaptiles/util/OmtLanguageUtils.java
+++ b/src/main/java/org/openmaptiles/util/OmtLanguageUtils.java
@@ -124,7 +124,7 @@ public class OmtLanguageUtils {
 
   private static Stream<String> getAllNameTranslationsBesidesEnglishAndGerman(Map<String, Object> tags) {
     return tags.entrySet().stream()
-      .filter(e -> !EN_DE_NAME_KEYS.contains(e.getKey()) && VALID_NAME_TAGS.test(e.getKey()))
+      .filter(e -> !EN_DE_NAME_KEYS.contains(e.getKey()) && isValidOsmNameTag(e.getKey()))
       .map(Map.Entry::getValue)
       .map(OmtLanguageUtils::string);
   }


### PR DESCRIPTION
Migrated validation of `name:*=*` subkeys from a regular expression that will be deprecated by onthegomap/planetiler#1404 to a preexisting method that will become more rigorous in the same PR.