### PR TITLE
[BUGFIX] Fix dropped road segments at z4-5

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -498,7 +498,8 @@ public class Transportation implements
       if (isPierPolygon(element)) {
         return;
       }
-      int minzoom = getMinzoom(element, highwayClass);
+      var minZoomAndNewClass = getMinzoomAndClass(element, highwayClass);
+      int minzoom = minZoomAndNewClass.minzoom;
 
       if (minzoom > config.maxzoom()) {
         return;
@@ -512,7 +513,7 @@ public class Transportation implements
 
       FeatureCollector.Feature feature = features.line(LAYER_NAME).setBufferPixels(BUFFER_SIZE)
         // main attributes at all zoom levels (used for grouping <= z8)
-        .setAttr(Fields.CLASS, highwayClass)
+        .setAttr(Fields.CLASS, coalesce(minZoomAndNewClass.classOverride, highwayClass))
         .setAttr(Fields.SUBCLASS, highwaySubclass(highwayClass, element.publicTransport(), highway))
         .setAttr(Fields.NETWORK, networkType != null ? networkType.name : null)
         .setAttrWithMinSize(Fields.BRUNNEL, brunnel(element.isBridge(), element.isTunnel(), element.isFord()), 4, 4, 12)
@@ -547,8 +548,6 @@ public class Transportation implements
   }
 
   private static final double TRUNK_Z0_UPGRADE_LENGTH = GeoUtils.metersToPixelAtEquator(0, 500);
-  // give it some extra buffer to account for snapping endpoints to tile grid
-  private static final double TRUNK_Z5_UPGRADE_LENGTH = 2 * GeoUtils.metersToPixelAtEquator(5, 500);
 
   private boolean isTrunkZ5MergeableLength(Tables.OsmHighwayLinestring element) {
     try {
@@ -560,7 +559,10 @@ public class Transportation implements
     }
   }
 
-  int getMinzoom(Tables.OsmHighwayLinestring element, String highwayClass) {
+  record MinZoomAndNewClass(int minzoom, ZoomFunction<String> classOverride) {}
+
+  MinZoomAndNewClass getMinzoomAndClass(Tables.OsmHighwayLinestring element, String highwayClass) {
+    ZoomFunction<String> highwayClassOverride = null;
     List<RouteRelation> routeRelations = getRouteRelations(element);
     int routeRank = 3;
     for (var rel : routeRelations) {
@@ -588,6 +590,8 @@ public class Transportation implements
           // Allow small trunk segments to be processed at z5 so they can merge with surrounding motorways
           if (isTrunkZ5MergeableLength(element)) {
             z5trunk = true;
+            highwayClassOverride =
+              z -> z <= 5 ? highwayClass.replace(baseClass, FieldValues.CLASS_MOTORWAY) : highwayClass;
           }
 
           // and if it is good for Z5, it may be good also for Z4 (see CLASS_MOTORWAY bellow):
@@ -595,6 +599,7 @@ public class Transportation implements
           if (z5trunk && isMotorwayWithNetworkForZ4(routeRelations)) {
             clazz = FieldValues.CLASS_MOTORWAY;
             z5trunk = false;
+            highwayClassOverride = null;
           }
           yield (z5trunk) ? 5 : MINZOOMS.getOrDefault(clazz, Integer.MAX_VALUE);
         }
@@ -607,13 +612,13 @@ public class Transportation implements
     if (isLink(highway) || isLink(construction)) {
       minzoom = Math.max(minzoom, 9);
     }
-    return minzoom;
+    return new MinZoomAndNewClass(minzoom, highwayClassOverride);
   }
 
   private boolean isPierPolygon(Tables.OsmHighwayLinestring element) {
     if ("pier".equals(element.manMade())) {
       try {
-        if (element.source().worldGeometry() instanceof LineString lineString && lineString.isClosed()) {
+        if (element.source().worldGeometry()instanceof LineString lineString && lineString.isClosed()) {
           // ignore this because it's a polygon
           return true;
         }
@@ -719,26 +724,6 @@ public class Transportation implements
       var oneway = item.tags().get(Fields.ONEWAY);
       if (oneway instanceof Number n && ONEWAY_VALUES.contains(n.intValue())) {
         item.tags().put(LIMIT_MERGE_TAG, onewayId++);
-      }
-    }
-
-    //Upgrade small trunk segments at z5 so they can merge with surrounding motorways
-    if (zoom == 5) {
-      for (var item : items) {
-        try {
-          var highway = item.tags().get(Fields.CLASS);
-          if (FieldValues.CLASS_TRUNK.equals(highway) &&
-            item.geometry().decode().getLength() <= TRUNK_Z5_UPGRADE_LENGTH) {
-            item.tags().put(Fields.CLASS, FieldValues.CLASS_MOTORWAY);
-          }
-          if (FieldValues.CLASS_TRUNK_CONSTRUCTION.equals(highway) &&
-            item.geometry().decode().getLength() <= TRUNK_Z5_UPGRADE_LENGTH) {
-            item.tags().put(Fields.CLASS, FieldValues.CLASS_MOTORWAY_CONSTRUCTION);
-          }
-        } catch (GeometryException e) {
-          e.log(stats, "omt_transportation_trunk_length_postprocess",
-            "Unable to get feature length for postprocess trunk upgrade: " + item.id());
-        }
       }
     }
 

--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -248,7 +248,7 @@ public class TransportationName implements
       isLink ? 13 : 12; // fallback - get from line minzoom, but floor at 12
 
     // inherit min zoom threshold from visible road, and ensure we never show a label on a road that's not visible yet.
-    minzoom = Math.max(minzoom, transportation.getMinzoom(element, highwayClass));
+    minzoom = Math.max(minzoom, transportation.getMinzoomAndClass(element, highwayClass).minzoom());
     if (minzoom > config.maxzoom()) {
       return;
     }

--- a/src/test/java/org/openmaptiles/layers/AbstractLayerTest.java
+++ b/src/test/java/org/openmaptiles/layers/AbstractLayerTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
+import org.locationtech.jts.geom.Geometry;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.util.Utils;
 
@@ -139,12 +140,16 @@ public abstract class AbstractLayerTest {
 
   SourceFeature lineFeatureWithLength(double length, Map<String, Object> props) {
     return SimpleFeature.create(
-      GeoUtils.worldToLatLonCoords(newLineString(0.5, 0.5, 0.5 + GeoUtils.metersToPixelAtEquator(0, length), 0.5)),
+      latLonLineWithLength(length),
       new HashMap<>(props),
       OpenMapTilesProfile.OSM_SOURCE,
       null,
       0
     );
+  }
+
+  private static Geometry latLonLineWithLength(double length) {
+    return GeoUtils.worldToLatLonCoords(newLineString(0.5, 0.5, 0.5 + GeoUtils.metersToPixelAtEquator(0, length), 0.5));
   }
 
   SourceFeature closedWayFeature(Map<String, Object> props) {
@@ -172,6 +177,19 @@ public abstract class AbstractLayerTest {
     return polygonFeatureWithArea(1, props);
   }
 
+
+  protected SimpleFeature lineFeatureWithRelation(double length, List<OsmRelationInfo> relationInfos,
+    Map<String, Object> map) {
+    return SimpleFeature.createFakeOsmFeature(
+      latLonLineWithLength(length),
+      map,
+      OpenMapTilesProfile.OSM_SOURCE,
+      null,
+      0,
+      (relationInfos == null ? List.<OsmRelationInfo>of() : relationInfos).stream()
+        .map(r -> new OsmReader.RelationMember<>("", r)).toList()
+    );
+  }
 
   protected SimpleFeature lineFeatureWithRelation(List<OsmRelationInfo> relationInfos,
     Map<String, Object> map) {

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -4,11 +4,9 @@ import static com.onthegomap.planetiler.TestUtils.newLineString;
 import static com.onthegomap.planetiler.TestUtils.newPoint;
 import static com.onthegomap.planetiler.TestUtils.rectangle;
 import static java.util.Map.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.onthegomap.planetiler.FeatureCollector;
-import com.onthegomap.planetiler.VectorTile;
 import com.onthegomap.planetiler.config.Arguments;
 import com.onthegomap.planetiler.config.PlanetilerConfig;
 import com.onthegomap.planetiler.geo.GeometryException;
@@ -18,7 +16,6 @@ import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.reader.osm.OsmRelationInfo;
 import com.onthegomap.planetiler.stats.Stats;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -2232,78 +2229,41 @@ class TransportationTest extends AbstractLayerTest {
     )), features);
   }
 
-  @Test
-  void testShortTrunkMerge() throws GeometryException {
-    var layer = Transportation.LAYER_NAME;
-
-    var motorwayZ6 = new VectorTile.Feature(
-      layer,
-      1,
-      VectorTile.encodeGeometry(newLineString(0, 0, 0.10, 0.10)),
-      new HashMap<>(Map.of("class", "motorway")),
-      0
-    );
-    var trunkZ6 = new VectorTile.Feature(
-      layer,
-      2,
-      VectorTile.encodeGeometry(newLineString(0.10, 0.10, 0.10, 0.2)),
-      new HashMap<>(Map.of("class", "trunk")),
-      0
-    );
-    var motorwayZ5 = new VectorTile.Feature(
-      layer,
-      1,
-      VectorTile.encodeGeometry(newLineString(0, 0, 0.10, 0.10)),
-      new HashMap<>(Map.of("class", "motorway")),
-      0
-    );
-    var trunkZ5 = new VectorTile.Feature(
-      layer,
-      2,
-      VectorTile.encodeGeometry(newLineString(0.10, 0.10, 0.10, 0.2)),
-      new HashMap<>(Map.of("class", "trunk")),
-      0
-    );
-
-    List<VectorTile.Feature> inputZ6 = List.of(motorwayZ6, trunkZ6);
-    List<VectorTile.Feature> inputZ5 = List.of(motorwayZ5, trunkZ5);
-
-    List<VectorTile.Feature> resultZ6 = profile.postProcessLayerFeatures(layer, 6, inputZ6);
-    List<VectorTile.Feature> resultZ5 = profile.postProcessLayerFeatures(layer, 5, inputZ5);
-
-    assertEquals(2, resultZ6.size(), "Should be separate features at zoom 6");
-    assertEquals(1, resultZ5.size(), "Should merge into a single feature at zoom 5");
-
-    VectorTile.Feature mergedFeatureZ5 = resultZ5.get(0);
-    assertEquals("motorway", mergedFeatureZ5.tags().get("class"), "Merged feature should be motorway class at zoom 5");
-
-    List<String> classesZ6 = resultZ6.stream()
-      .map(f -> (String) f.tags().get("class"))
-      .toList();
-    assertEquals(List.of("motorway", "trunk"), classesZ6, "At zoom 6, should have motorway and trunk classes");
-  }
-
   @ParameterizedTest
   @CsvSource({
-    "499, trunk, 5",
-    "501, trunk, 6",
-    "499, trunk_link, 9", // Links have minzoom=9 regardless of length
+    "499, trunk, 5, 5, motorway",
+    "499, trunk, 5, 6, trunk",
+    "501, trunk, 6, 5, trunk",
+    "501, trunk, 6, 6, trunk",
+    "499, trunk_link, 9, 9, trunk", // Links have minzoom=9 regardless of length
   })
-  void testShortTrunkGetsZ5(int length, String highway, int expectedMinZoom) {
-    // Test that a short trunk segment (< 1000m) gets minzoom=5
+  void testShortTrunkGetsZ5(int length, String highway, int expectedMinZoom, int classZoom,
+    String expectedClass) {
+    // Test that a short trunk segment (< 500m) gets minzoom=5
     FeatureCollector features = process(lineFeatureWithLength(length, Map.of(
       "highway", highway
     )));
 
-    assertFeatures(13, List.of(Map.of(
+    assertFeatures(classZoom, List.of(Map.of(
       "_layer", "transportation",
-      "class", "trunk",
+      "class", expectedClass,
+      "_minzoom", expectedMinZoom
+    )), features);
+
+    features = process(lineFeatureWithLength(length, Map.of(
+      "highway", "construction",
+      "construction", highway
+    )));
+
+    assertFeatures(classZoom, List.of(Map.of(
+      "_layer", "transportation",
+      "class", expectedClass + "_construction",
       "_minzoom", expectedMinZoom
     )), features);
   }
 
   @Test
-  void testNetworkQualifiedTrunkGetsZ5() {
+  void testNetworkQualifiedTrunkGetsZ5ButNotMotorway() {
     // Test that network-qualified trunks get z5 (or z4 if they qualify for z4)
     // Network qualification should override length check
     var rel = new OsmElement.Relation(1);
@@ -2312,7 +2272,7 @@ class TransportationTest extends AbstractLayerTest {
     rel.setTag("network", "US:I");
     rel.setTag("ref", "95");
 
-    FeatureCollector features = process(lineFeatureWithRelation(
+    FeatureCollector features = process(lineFeatureWithRelation(400,
       profile.preprocessOsmRelation(rel),
       Map.of(
         "highway", "trunk",
@@ -2322,10 +2282,10 @@ class TransportationTest extends AbstractLayerTest {
 
     // US:I network qualifies for z4, not z5
     // Network-qualified trunks create both transportation and transportation_name features
-    assertFeatures(13, List.of(
+    assertFeatures(5, List.of(
       Map.of(
         "_layer", "transportation",
-        "class", "trunk",
+        "class", "trunk", // don't upgrade to motorway
         "network", "us-interstate",
         "_minzoom", 4 // US:I network qualifies for z4
       ),
@@ -2335,52 +2295,5 @@ class TransportationTest extends AbstractLayerTest {
         "network", "us-interstate"
       )
     ), features);
-  }
-
-  @Test
-  void testContiguousTrunksMergeAndUpgrade() throws GeometryException {
-    // Test that small individual trunk segments (< 1000m) are upgraded to motorway at z5
-    var layer = Transportation.LAYER_NAME;
-
-    // Create small individual trunk segment. This should upgrade to motorway at z5
-    var trunk = new VectorTile.Feature(
-      layer, 1, VectorTile.encodeGeometry(newLineString(0, 0, 0.1, 0)),
-      new HashMap<>(Map.of("class", "trunk")), 0
-    );
-
-    List<VectorTile.Feature> inputZ5 = List.of(trunk);
-    List<VectorTile.Feature> resultZ5 = profile.postProcessLayerFeatures(layer, 5, inputZ5);
-
-    // Trunk should be upgraded to motorway (small individual segment)
-    assertEquals(1, resultZ5.size(), "Should have 1 feature");
-    assertEquals("motorway", resultZ5.get(0).tags().get("class"),
-      "Small individual trunk segment should upgrade to motorway at z5");
-  }
-
-  @Test
-  void testDisconnectedTrunksStaySeparate() throws GeometryException {
-    // Test that disconnected small individual trunk segments upgrade independently
-    var layer = Transportation.LAYER_NAME;
-
-    // Two disconnected small individual segments
-    // Use different coordinates and add oneway tag to prevent merging
-    var trunk1 = new VectorTile.Feature(
-      layer, 1, VectorTile.encodeGeometry(newLineString(0, 0, 0.1, 0)),
-      new HashMap<>(Map.of("class", "trunk", "oneway", 1)), 0
-    );
-    var trunk2 = new VectorTile.Feature(
-      layer, 2, VectorTile.encodeGeometry(newLineString(0, 0.1, 0.1, 0.1)),
-      new HashMap<>(Map.of("class", "trunk", "oneway", 1)), 0
-    );
-
-    List<VectorTile.Feature> inputZ5 = List.of(trunk1, trunk2);
-    List<VectorTile.Feature> resultZ5 = profile.postProcessLayerFeatures(layer, 5, inputZ5);
-
-    // Both should upgrade to motorway (small individual segments, oneway prevents merging)
-    assertEquals(2, resultZ5.size(), "Both small individual segments should upgrade");
-    for (var feature : resultZ5) {
-      assertEquals("motorway", feature.tags().get("class"),
-        "Each small individual segment should upgrade to motorway");
-    }
   }
 }


### PR DESCRIPTION
Planetiler implementation of openmaptiles/openmaptiles#1767.

Replicated implementation into Java and added test cases to cover this behavior.

Canada z4 behavior validated in Ontario:

<img width="854" height="786" alt="image" src="https://github.com/user-attachments/assets/f1e5463c-cd30-48d2-ae40-062d7d62cad4" />

Iowa z5 behavior:

<img width="544" height="439" alt="image" src="https://github.com/user-attachments/assets/f6ccfede-2dab-496c-9795-edd10f7e2142" />
