### PR TITLE
bumped version to 3.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.openmaptiles</groupId>
   <artifactId>planetiler-openmaptiles</artifactId>
-  <version>3.16.0-SNAPSHOT</version>
+  <version>3.16.1-SNAPSHOT</version>
 
   <name>OpenMapTiles Vector Tile Schema implementation for Planetiler tool</name>
 


### PR DESCRIPTION
3.16 was released, so bumped up version:

- currently 3.16.1 assuming we'll be merging bug-fixes
- or later may be adjusted to 3.17, if we merge also some new features