### PR TITLE
Add rock, clay, laterite to SURFACE_UNPAVED_VALUES

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -131,7 +131,7 @@ public class Transportation implements
   );
   private static final Set<String> SURFACE_UNPAVED_VALUES = Set.of(
     "unpaved", "compacted", "dirt", "earth", "fine_gravel", "grass", "grass_paver", "gravel", "gravel_turf", "ground",
-    "ice", "mud", "pebblestone", "salt", "sand", "snow", "woodchips"
+    "ice", "mud", "pebblestone", "salt", "sand", "snow", "woodchips", "rock", "clay", "laterite"
   );
   private static final Set<String> SURFACE_PAVED_VALUES = Set.of(
     "paved", "asphalt", "cobblestone", "concrete", "concrete:lanes", "concrete:plates", "metal",

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -149,6 +149,23 @@ class TransportationTest extends AbstractLayerTest {
   }
 
   @Test
+  void testRockClayLateriteSurfaces() {
+    for (var surface : List.of("rock", "clay", "laterite")) {
+      assertFeatures(14, List.of(Map.of(
+        "_layer", "transportation",
+        "class", "path",
+        "subclass", "path",
+        "surface", "unpaved",
+        "oneway", "<null>",
+        "_minzoom", 14
+      )), process(lineFeature(Map.of(
+        "surface", surface,
+        "highway", "path"
+      ))));
+    }
+  }
+
+  @Test
   void testPrivatePath() {
     assertFeatures(9, List.of(Map.of(
       "_layer", "transportation",

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -148,21 +148,20 @@ class TransportationTest extends AbstractLayerTest {
     ))));
   }
 
-  @Test
-  void testRockClayLateriteSurfaces() {
-    for (var surface : List.of("rock", "clay", "laterite")) {
-      assertFeatures(14, List.of(Map.of(
-        "_layer", "transportation",
-        "class", "path",
-        "subclass", "path",
-        "surface", "unpaved",
-        "oneway", "<null>",
-        "_minzoom", 14
-      )), process(lineFeature(Map.of(
-        "surface", surface,
-        "highway", "path"
-      ))));
-    }
+  @ParameterizedTest
+  @ValueSource(strings = {"rock", "clay", "laterite"})
+  void testRockClayLateriteSurfaces(String surface) {
+    assertFeatures(14, List.of(Map.of(
+      "_layer", "transportation",
+      "class", "path",
+      "subclass", "path",
+      "surface", "unpaved",
+      "oneway", "<null>",
+      "_minzoom", 14
+    )), process(lineFeature(Map.of(
+      "surface", surface,
+      "highway", "path"
+    ))));
   }
 
   @Test


### PR DESCRIPTION
## Summary
`SURFACE_UNPAVED_VALUES` in `Transportation.java` is missing three fairly common values that fall through unclassified today:

- `rock`: 34,201 uses (taginfo)
- `clay`: 42,844 uses
- `laterite`: 2,250 uses, documented via OSM's approved [Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite) (29-0-0)

All three exceed the usage of values already in the set (`salt` at 511, `snow` at 508). Companion PR for the same gap in the SQL-based schema: openmaptiles/openmaptiles#1807.

Related to openmaptiles/openmaptiles#1806

## Test plan
- [x] Added `testRockClayLateriteSurfaces` to `TransportationTest.java`, mirroring the existing `testUnnamedPath` pattern
- [ ] Couldn't run the suite locally (this environment doesn't have the JDK 21 toolchain this project requires), relying on CI here